### PR TITLE
Fix import in typescript.mdx

### DIFF
--- a/website/pages/docs/core-concepts/typescript.mdx
+++ b/website/pages/docs/core-concepts/typescript.mdx
@@ -54,7 +54,7 @@ Read [styled-components TypeScript guide](https://styled-components.com/docs/api
 // import original module declarations
 import '@xstyled/system'
 import '@emotion/react'
-import { ITheme, DefaultTheme as XStyledDefaultTheme } from '@xstyled/styled-components'
+import { ITheme, DefaultTheme as XStyledDefaultTheme } from '@xstyled/emotion'
 
 interface AppTheme extends ITheme, XStyledDefaultTheme {
   /* Customize your theme */


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

In the example for @xstyled/emotion, fix the wrong import of @xstyled/styled-components.
