### PR TITLE
Fix media query description in magic-styled-components.mdx

### DIFF
--- a/website/pages/docs/core-concepts/magic-styled-components.mdx
+++ b/website/pages/docs/core-concepts/magic-styled-components.mdx
@@ -40,7 +40,7 @@ Here's how the example above works:
 - `default` is replaced by `theme.transitions.default`
 - `emerald-500` is replaced by `theme.colors['emerald-500']`
 - `#fff` is replaced by `theme.colors['#fff']`, that is not defined, so it uses `#fff` as value
-- `@media (min-width: md)` is replaced by `@media (min-width: ${theme.screens.lg})`
+- `@media (min-width: md)` is replaced by `@media (min-width: ${theme.screens.md})`
 - `lg` is replaced by `theme.fontSizes.lg`
 
 ## Use another component


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

The description for media query in `magic-styled-components.mdx` is looks like incorrect.
<img width="564" alt="图片" src="https://github.com/sweetliquid/xstyled/assets/18693190/6bd16ac3-4f41-4a7e-af00-76c9dd148866">

at https://xstyled.dev/docs/magic-styled-components/#automatic-theming.

## Test plan

Just document update.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
