### PR TITLE
docs: add styled rules description supplement

### DIFF
--- a/website/pages/docs/core-concepts/magic-styled-components.mdx
+++ b/website/pages/docs/core-concepts/magic-styled-components.mdx
@@ -294,7 +294,7 @@ import styled from '@xstyled/...'
 
 const Box = styled.div({
   margin: 2, // '2px' (not transformed by xstyled)
-  marginTop: '2', // '8px' (transformed by xstyled)
+  marginTop: '2', // '8px' (transformed by xstyled to your defined theme spacing scale)
 })
 ```
 

--- a/website/pages/docs/core-concepts/magic-styled-components.mdx
+++ b/website/pages/docs/core-concepts/magic-styled-components.mdx
@@ -294,7 +294,7 @@ import styled from '@xstyled/...'
 
 const Box = styled.div({
   margin: 2, // '2px' (not transformed by xstyled)
-  marginTop: '2', // '8px' (transformed by styled)
+  marginTop: '2', // '8px' (transformed by xstyled)
 })
 ```
 


### PR DESCRIPTION
## Summary

description is for xstyled, not styled.

```
const Box = styled.div({
  margin: 2, // '2px' (not transformed by xstyled)
  marginTop: '2', // '8px' (transformed by styled)
})
```

and description of value conversion by theme is insufficient.

## Test plan

Just document update.
