### PR TITLE
fix(system): durable SynthesizedPath + type-test suite + bench

### DIFF
--- a/.changeset/synthesized-path-numeric-keys.md
+++ b/.changeset/synthesized-path-numeric-keys.md
@@ -1,0 +1,7 @@
+---
+'@xstyled/system': patch
+'@xstyled/styled-components': patch
+'@xstyled/emotion': patch
+---
+
+Themes with numeric keys (for example `{ blue: { 50: '#…', 100: '#…' } }`) now produce precise string-literal types like `'blue.50' | 'blue.100'` instead of silently dropping out of the union. Deeply nested themes also type-check cleanly without producing "union too complex" errors.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Lint
         run: yarn lint
 
+      - name: Type tests
+        run: yarn check:types
+
       - name: Test
         run: yarn test --coverage
 

--- a/build/rollup.config.js
+++ b/build/rollup.config.js
@@ -42,7 +42,11 @@ export default [
     ],
   }),
   bundle({
-    plugins: [dts()],
+    // Each package's tsconfig declares `paths` so workspace deps resolve
+    // from source for `yarn check:types`. The published `dist/index.d.ts`
+    // must instead reference siblings by their npm name, so override paths
+    // (and baseUrl) here to drop the source mapping during the dts emit.
+    plugins: [dts({ compilerOptions: { paths: {}, baseUrl: '.' } })],
     output: {
       file: `dist/index.d.ts`,
       format: 'es',

--- a/jest.config.js
+++ b/jest.config.js
@@ -4,7 +4,7 @@ module.exports = {
   transform: {
     '^.+\\.(j|t)sx?$': 'babel-jest',
   },
-  testPathIgnorePatterns: ['/node_modules/', '/website/'],
+  testPathIgnorePatterns: ['/node_modules/', '/website/', '/__type-tests__/'],
   coveragePathIgnorePatterns: ['/node_modules/', '/dist/'],
   moduleNameMapper: {
     'styled-components':

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "release": "lerna publish --conventional-commits && conventional-github-releaser --preset angular",
     "test": "jest",
     "bench:runtime": "node scripts/bench-runtime.mjs",
-    "check:types": "tsc -p packages/system/tsconfig.types.json && tsc -p packages/system/tsconfig.aug.json",
+    "check:types": "node scripts/check-types.mjs",
     "bench:types": "node scripts/bench-types.mjs"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "release": "lerna publish --conventional-commits && conventional-github-releaser --preset angular",
     "test": "jest",
     "bench:runtime": "node scripts/bench-runtime.mjs",
-    "check:types": "tsc -p packages/system/tsconfig.types.json",
+    "check:types": "tsc -p packages/system/tsconfig.types.json && tsc -p packages/system/tsconfig.aug.json",
     "bench:types": "node scripts/bench-types.mjs"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
     "lint": "eslint .",
     "release": "lerna publish --conventional-commits && conventional-github-releaser --preset angular",
     "test": "jest",
-    "bench:runtime": "node scripts/bench-runtime.mjs"
+    "bench:runtime": "node scripts/bench-runtime.mjs",
+    "check:types": "tsc -p packages/system/tsconfig.types.json",
+    "bench:types": "node scripts/bench-types.mjs"
   },
   "devDependencies": {
     "@babel/core": "^7.19.3",

--- a/packages/babel-preset-emotion-css-prop/tsconfig.json
+++ b/packages/babel-preset-emotion-css-prop/tsconfig.json
@@ -1,5 +1,7 @@
 {
-  "include": ["src"],
+  "include": [
+    "src"
+  ],
   "compilerOptions": {
     "strict": true,
     "noUnusedLocals": true,
@@ -11,6 +13,21 @@
     "esModuleInterop": true,
     "moduleResolution": "node",
     "jsx": "react",
-    "sourceMap": true
+    "sourceMap": true,
+    "baseUrl": ".",
+    "paths": {
+      "@xstyled/util": [
+        "../util/src"
+      ],
+      "@xstyled/prop-types": [
+        "../prop-types/src"
+      ],
+      "@xstyled/system": [
+        "../system/src"
+      ],
+      "@xstyled/core": [
+        "../core/src"
+      ]
+    }
   }
 }

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,5 +1,7 @@
 {
-  "include": ["src"],
+  "include": [
+    "src"
+  ],
   "compilerOptions": {
     "strict": true,
     "noUnusedLocals": true,
@@ -11,6 +13,21 @@
     "esModuleInterop": true,
     "moduleResolution": "node",
     "jsx": "react",
-    "sourceMap": true
+    "sourceMap": true,
+    "baseUrl": ".",
+    "paths": {
+      "@xstyled/util": [
+        "../util/src"
+      ],
+      "@xstyled/prop-types": [
+        "../prop-types/src"
+      ],
+      "@xstyled/system": [
+        "../system/src"
+      ],
+      "@xstyled/core": [
+        "../core/src"
+      ]
+    }
   }
 }

--- a/packages/emotion/src/__type-tests__/_helpers.ts
+++ b/packages/emotion/src/__type-tests__/_helpers.ts
@@ -1,0 +1,11 @@
+export type Expect<T extends true> = T
+
+export type Equal<A, B> = (<X>() => X extends A ? 1 : 2) extends <
+  X,
+>() => X extends B ? 1 : 2
+  ? true
+  : false
+
+export type Assignable<T, V> = [V] extends [T] ? true : false
+export type NotAssignable<T, V> = Assignable<T, V> extends true ? false : true
+export type IsNever<T> = [T] extends [never] ? true : false

--- a/packages/emotion/src/__type-tests__/cx-jsx.test-d.tsx
+++ b/packages/emotion/src/__type-tests__/cx-jsx.test-d.tsx
@@ -1,0 +1,54 @@
+import * as React from 'react'
+import { cx, jsx, css } from '../index'
+import type { Expect, Assignable, IsNever } from './_helpers'
+
+// -----------------------------------------------------------------------------
+// `cx` accepts a single styles fn or an array; returns a string or a
+// theme-fn (see emotion/src/createCx.ts).
+// -----------------------------------------------------------------------------
+{
+  const a = cx(
+    css`
+      color: red;
+    `,
+  )
+  // The runtime return type is string | (theme) => any; we just assert it
+  // isn't `never` / `any`.
+  type _t = Expect<IsNever<typeof a> extends true ? false : true>
+  void (null as unknown as _t)
+}
+
+{
+  const a = cx([
+    css`
+      color: red;
+    `,
+    css`
+      margin: 4px;
+    `,
+  ])
+  type _t = Expect<IsNever<typeof a> extends true ? false : true>
+  void (null as unknown as _t)
+}
+
+// -----------------------------------------------------------------------------
+// `jsx` mirrors the emotion `jsx` factory.
+// -----------------------------------------------------------------------------
+export const _jsx_via_factory = jsx('div', { children: 'hi' })
+
+// jsx accepts an ElementType and props.
+export type _jsx_callable = Expect<Assignable<Function, typeof jsx>>
+
+// -----------------------------------------------------------------------------
+// Negative scenarios.
+// -----------------------------------------------------------------------------
+
+// @ts-expect-error `cx` requires a SerializedStylesFn (or array); a bare
+// number is not acceptable
+cx(42)
+
+// @ts-expect-error jsx requires an ElementType as the first arg
+jsx({}, { children: 'oops' })
+
+// Suppress unused-import warnings under the types tsconfig.
+void React

--- a/packages/emotion/src/__type-tests__/hooks.test-d.ts
+++ b/packages/emotion/src/__type-tests__/hooks.test-d.ts
@@ -1,0 +1,101 @@
+import {
+  useTheme,
+  useTh,
+  useColor,
+  useSpace,
+  useFontSize,
+  useRadius,
+  useShadow,
+  useZIndex,
+  useUp,
+  useDown,
+  useBreakpoint,
+  useScreens,
+  useColorMode,
+} from '../index'
+import type { CSSScalar, Screens } from '../index'
+import type { Expect, Equal, IsNever } from './_helpers'
+
+// React's rules-of-hooks linter requires hook calls to live inside a
+// function whose name starts with `use` or with a capital letter; these
+// helpers are never invoked at runtime — only type-checked.
+
+function _useThemeAssertions() {
+  const theme = useTheme()
+  // emotion's useTheme returns its own augmentable Theme — we only assert
+  // it isn't `never`.
+  type _t = Expect<IsNever<typeof theme> extends true ? false : true>
+  void (null as unknown as _t)
+}
+void _useThemeAssertions
+
+function _useThAssertions() {
+  const value = useTh('colors.primary')
+  type _t = Expect<Equal<typeof value, CSSScalar>>
+  void (null as unknown as _t)
+}
+void _useThAssertions
+
+function _useTokenHookAssertions() {
+  const c = useColor('primary')
+  const s = useSpace(2)
+  const f = useFontSize('lg')
+  const r = useRadius('md')
+  const z = useZIndex(10)
+  const shadow = useShadow('md')
+  type _c = Expect<Equal<typeof c, CSSScalar>>
+  type _s = Expect<Equal<typeof s, CSSScalar>>
+  type _f = Expect<Equal<typeof f, CSSScalar>>
+  type _r = Expect<Equal<typeof r, CSSScalar>>
+  type _z = Expect<Equal<typeof z, CSSScalar>>
+  type _shadow = Expect<Equal<typeof shadow, CSSScalar>>
+  void (null as unknown as _c)
+  void (null as unknown as _s)
+  void (null as unknown as _f)
+  void (null as unknown as _r)
+  void (null as unknown as _z)
+  void (null as unknown as _shadow)
+}
+void _useTokenHookAssertions
+
+function _useBreakpointAssertions() {
+  const up = useUp('md')
+  const upNum = useUp(768)
+  const down = useDown('lg')
+  const bp = useBreakpoint()
+  const screens = useScreens()
+  type _up = Expect<Equal<typeof up, boolean>>
+  type _upNum = Expect<Equal<typeof upNum, boolean>>
+  type _down = Expect<Equal<typeof down, boolean>>
+  type _bp = Expect<Equal<typeof bp, string | null>>
+  type _screens = Expect<Equal<typeof screens, Screens>>
+  void (null as unknown as _up)
+  void (null as unknown as _upNum)
+  void (null as unknown as _down)
+  void (null as unknown as _bp)
+  void (null as unknown as _screens)
+}
+void _useBreakpointAssertions
+
+function _useBreakpointNegations() {
+  // @ts-expect-error booleans aren't valid breakpoint keys
+  useUp(true)
+  // @ts-expect-error objects aren't valid breakpoint keys
+  useUp({ key: 'md' })
+  // @ts-expect-error booleans aren't valid breakpoint keys
+  useDown(false)
+}
+void _useBreakpointNegations
+
+function _useColorModeAssertions() {
+  const [mode, setMode] = useColorMode()
+  type _mode = Expect<Equal<typeof mode, string | null>>
+  type _setMode = Expect<Equal<typeof setMode, (mode: string | null) => void>>
+  void (null as unknown as _mode)
+  void (null as unknown as _setMode)
+}
+void _useColorModeAssertions
+
+export type _hookExists = Expect<
+  IsNever<typeof useTh> extends true ? false : true
+>

--- a/packages/emotion/src/__type-tests__/styled.test-d.tsx
+++ b/packages/emotion/src/__type-tests__/styled.test-d.tsx
@@ -1,0 +1,62 @@
+import * as React from 'react'
+import styled, { css, createGlobalStyle, keyframes } from '../index'
+import type { Expect, Assignable, IsNever } from './_helpers'
+
+// -----------------------------------------------------------------------------
+// `styled.div`...`` returns a React component.
+// -----------------------------------------------------------------------------
+const Box = styled.div`
+  color: red;
+  margin: 8px;
+`
+
+export const _jsx_Box = <Box />
+export const _jsx_Box_with_kids = <Box>hello</Box>
+
+export type _Box_is_element_type = Expect<
+  Assignable<React.ElementType, typeof Box>
+>
+
+// -----------------------------------------------------------------------------
+// `styled('div')` is the function form.
+// -----------------------------------------------------------------------------
+const Fn = styled('button')`
+  color: white;
+`
+export const _jsx_Fn = <Fn onClick={() => undefined}>x</Fn>
+
+// -----------------------------------------------------------------------------
+// `css\`...\`` is interpolatable.
+// -----------------------------------------------------------------------------
+const tokens = css`
+  color: red;
+`
+const Composed = styled.div`
+  ${tokens};
+  margin: 4px;
+`
+export const _jsx_Composed = <Composed />
+
+export type _css_callable = Expect<
+  IsNever<ReturnType<typeof css>> extends true ? false : true
+>
+
+// -----------------------------------------------------------------------------
+// `createGlobalStyle` returns a React component.
+// -----------------------------------------------------------------------------
+const Globals = createGlobalStyle`
+  body { margin: 0; }
+`
+export const _jsx_Globals = <Globals />
+
+// -----------------------------------------------------------------------------
+// `keyframes` (re-exported from @emotion/react).
+// -----------------------------------------------------------------------------
+const Anim = keyframes`
+  from { opacity: 0; }
+  to   { opacity: 1; }
+`
+const Animated = styled.div`
+  animation: ${Anim} 200ms linear;
+`
+export const _jsx_Animated = <Animated />

--- a/packages/emotion/src/__type-tests__/x.test-d.tsx
+++ b/packages/emotion/src/__type-tests__/x.test-d.tsx
@@ -1,0 +1,43 @@
+import * as React from 'react'
+import { x } from '../index'
+import type { Expect, Assignable, IsNever } from './_helpers'
+
+// -----------------------------------------------------------------------------
+// `x` is a record of styled tags. Every supported HTML element is callable.
+// In emotion's typings the underlying HTML attributes are *not* automatically
+// surfaced (a long-standing emotion / @emotion/styled quirk), so we only
+// assert system props + minimal JSX usage here.
+// -----------------------------------------------------------------------------
+export type _x_has_div = Expect<IsNever<typeof x.div> extends true ? false : true>
+export type _x_has_a = Expect<IsNever<typeof x.a> extends true ? false : true>
+export type _x_has_button = Expect<
+  IsNever<typeof x.button> extends true ? false : true
+>
+
+// JSX usage with system props (the core promise).
+export const _jsx_basic = <x.div />
+export const _jsx_with_system_props = <x.div m={2} p={1} display="flex" />
+export const _jsx_responsive_space = <x.div m={{ _: 1, md: 2, lg: 4 }} />
+export const _jsx_color = <x.div color="red" backgroundColor="#fff" />
+
+export const _jsx_children = <x.div>hello</x.div>
+
+// -----------------------------------------------------------------------------
+// Negative scenarios — value-level @ts-expect-error.
+// -----------------------------------------------------------------------------
+
+const _badM = (
+  // @ts-expect-error `null` is excluded by the `{}` arm of ThemeNamespaceValue
+  <x.div m={null} />
+)
+void _badM
+
+// -----------------------------------------------------------------------------
+// Assignability sanity — `x.div` is a valid JSX component type.
+// -----------------------------------------------------------------------------
+export type _xdiv_is_jsx_component = Expect<
+  Assignable<React.ElementType, typeof x.div>
+>
+
+// Suppress unused-import warning under the types tsconfig.
+void React

--- a/packages/emotion/src/css.test.tsx
+++ b/packages/emotion/src/css.test.tsx
@@ -94,8 +94,10 @@ describe('#css', () => {
   it('runs function-form template interpolations against theme props', () => {
     const Dummy = styled.div`
       ${css`
-        margin: ${(p: { theme: { space: { 1: number; 2: number } } }) =>
-          `${p.theme.space[1]}px ${p.theme.space[2]}px`};
+        margin: ${(p) => {
+          const space = (p.theme as { space: { 1: number; 2: number } }).space
+          return `${space[1]}px ${space[2]}px`
+        }};
       `}
     `
     const { container } = render(

--- a/packages/emotion/src/css.test.tsx
+++ b/packages/emotion/src/css.test.tsx
@@ -79,7 +79,7 @@ describe('#css', () => {
 
   it('accepts function', () => {
     const Dummy = styled.div`
-      ${css((p) => ({
+      ${css(() => ({
         margin: '1 2',
       }))}
     `

--- a/packages/emotion/tsconfig.json
+++ b/packages/emotion/tsconfig.json
@@ -1,6 +1,10 @@
 {
-  "include": ["src"],
-  "exclude": ["src/__type-tests__"],
+  "include": [
+    "src"
+  ],
+  "exclude": [
+    "src/__type-tests__"
+  ],
   "compilerOptions": {
     "strict": true,
     "noUnusedLocals": true,
@@ -12,6 +16,21 @@
     "esModuleInterop": true,
     "moduleResolution": "node",
     "jsx": "react",
-    "sourceMap": true
+    "sourceMap": true,
+    "baseUrl": ".",
+    "paths": {
+      "@xstyled/util": [
+        "../util/src"
+      ],
+      "@xstyled/prop-types": [
+        "../prop-types/src"
+      ],
+      "@xstyled/system": [
+        "../system/src"
+      ],
+      "@xstyled/core": [
+        "../core/src"
+      ]
+    }
   }
 }

--- a/packages/emotion/tsconfig.json
+++ b/packages/emotion/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "include": ["src"],
+  "exclude": ["src/__type-tests__"],
   "compilerOptions": {
     "strict": true,
     "noUnusedLocals": true,

--- a/packages/emotion/tsconfig.types.json
+++ b/packages/emotion/tsconfig.types.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src/__type-tests__"],
+  "exclude": [],
+  "compilerOptions": {
+    "noEmit": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "skipLibCheck": true
+  }
+}

--- a/packages/prop-types/tsconfig.json
+++ b/packages/prop-types/tsconfig.json
@@ -1,5 +1,7 @@
 {
-  "include": ["src"],
+  "include": [
+    "src"
+  ],
   "compilerOptions": {
     "strict": true,
     "noUnusedLocals": true,
@@ -11,6 +13,21 @@
     "esModuleInterop": true,
     "moduleResolution": "node",
     "jsx": "react",
-    "sourceMap": true
+    "sourceMap": true,
+    "baseUrl": ".",
+    "paths": {
+      "@xstyled/util": [
+        "../util/src"
+      ],
+      "@xstyled/prop-types": [
+        "../prop-types/src"
+      ],
+      "@xstyled/system": [
+        "../system/src"
+      ],
+      "@xstyled/core": [
+        "../core/src"
+      ]
+    }
   }
 }

--- a/packages/styled-components/src/__type-tests__/_helpers.ts
+++ b/packages/styled-components/src/__type-tests__/_helpers.ts
@@ -1,0 +1,11 @@
+export type Expect<T extends true> = T
+
+export type Equal<A, B> = (<X>() => X extends A ? 1 : 2) extends <
+  X,
+>() => X extends B ? 1 : 2
+  ? true
+  : false
+
+export type Assignable<T, V> = [V] extends [T] ? true : false
+export type NotAssignable<T, V> = Assignable<T, V> extends true ? false : true
+export type IsNever<T> = [T] extends [never] ? true : false

--- a/packages/styled-components/src/__type-tests__/hooks.test-d.ts
+++ b/packages/styled-components/src/__type-tests__/hooks.test-d.ts
@@ -1,0 +1,100 @@
+import {
+  useTheme,
+  useTh,
+  useColor,
+  useSpace,
+  useFontSize,
+  useRadius,
+  useShadow,
+  useZIndex,
+  useUp,
+  useDown,
+  useBreakpoint,
+  useScreens,
+  useColorMode,
+} from '../index'
+import type { Theme, CSSScalar, Screens } from '../index'
+import type { Expect, Equal, IsNever } from './_helpers'
+
+// React's rules-of-hooks linter requires hook calls to live inside a
+// function whose name starts with `use` or with a capital letter; these
+// helpers are never invoked at runtime — only type-checked.
+
+function _useThemeAssertions() {
+  const theme = useTheme()
+  type _t = Expect<Equal<typeof theme, Theme>>
+  void (null as unknown as _t)
+}
+void _useThemeAssertions
+
+function _useThAssertions() {
+  const value = useTh('colors.primary')
+  type _t = Expect<Equal<typeof value, CSSScalar>>
+  void (null as unknown as _t)
+}
+void _useThAssertions
+
+function _useTokenHookAssertions() {
+  const c = useColor('primary')
+  const s = useSpace(2)
+  const f = useFontSize('lg')
+  const r = useRadius('md')
+  const z = useZIndex(10)
+  const shadow = useShadow('md')
+  type _c = Expect<Equal<typeof c, CSSScalar>>
+  type _s = Expect<Equal<typeof s, CSSScalar>>
+  type _f = Expect<Equal<typeof f, CSSScalar>>
+  type _r = Expect<Equal<typeof r, CSSScalar>>
+  type _z = Expect<Equal<typeof z, CSSScalar>>
+  type _shadow = Expect<Equal<typeof shadow, CSSScalar>>
+  void (null as unknown as _c)
+  void (null as unknown as _s)
+  void (null as unknown as _f)
+  void (null as unknown as _r)
+  void (null as unknown as _z)
+  void (null as unknown as _shadow)
+}
+void _useTokenHookAssertions
+
+function _useBreakpointAssertions() {
+  const up = useUp('md')
+  const upNum = useUp(768)
+  const down = useDown('lg')
+  const bp = useBreakpoint()
+  const screens = useScreens()
+  type _up = Expect<Equal<typeof up, boolean>>
+  type _upNum = Expect<Equal<typeof upNum, boolean>>
+  type _down = Expect<Equal<typeof down, boolean>>
+  type _bp = Expect<Equal<typeof bp, string | null>>
+  type _screens = Expect<Equal<typeof screens, Screens>>
+  void (null as unknown as _up)
+  void (null as unknown as _upNum)
+  void (null as unknown as _down)
+  void (null as unknown as _bp)
+  void (null as unknown as _screens)
+}
+void _useBreakpointAssertions
+
+// useUp / useDown only accept string | number, not arbitrary objects (#378).
+function _useBreakpointNegations() {
+  // @ts-expect-error `useUp` does not accept booleans
+  useUp(true)
+  // @ts-expect-error `useUp` does not accept objects
+  useUp({ key: 'md' })
+  // @ts-expect-error `useDown` does not accept booleans
+  useDown(false)
+}
+void _useBreakpointNegations
+
+function _useColorModeAssertions() {
+  const [mode, setMode] = useColorMode()
+  type _mode = Expect<Equal<typeof mode, string | null>>
+  type _setMode = Expect<Equal<typeof setMode, (mode: string | null) => void>>
+  void (null as unknown as _mode)
+  void (null as unknown as _setMode)
+}
+void _useColorModeAssertions
+
+export type _hookExists = Expect<
+  IsNever<typeof useTh> extends true ? false : true
+>

--- a/packages/styled-components/src/__type-tests__/styled.test-d.tsx
+++ b/packages/styled-components/src/__type-tests__/styled.test-d.tsx
@@ -1,0 +1,97 @@
+import * as React from 'react'
+import { styled, css, createGlobalStyle, keyframes } from '../index'
+import type { Expect, Assignable, IsNever } from './_helpers'
+
+// -----------------------------------------------------------------------------
+// `styled.div`...`` returns a React component.
+// -----------------------------------------------------------------------------
+const Box = styled.div`
+  color: red;
+  margin: 8px;
+`
+
+export const _jsx_Box = <Box />
+export const _jsx_Box_with_kids = <Box>hello</Box>
+export const _jsx_Box_as = <Box as="a" href="https://example.com" />
+
+// Box is assignable to React.ElementType.
+export type _Box_is_element_type = Expect<
+  Assignable<React.ElementType, typeof Box>
+>
+
+// -----------------------------------------------------------------------------
+// `styled('div')` is the function form. The resulting component accepts the
+// underlying element's HTML attrs plus system props.
+// -----------------------------------------------------------------------------
+const Fn = styled('button')`
+  color: white;
+`
+export const _jsx_Fn = <Fn onClick={() => undefined}>x</Fn>
+
+// -----------------------------------------------------------------------------
+// `.attrs` / `.withConfig` chaining.
+// -----------------------------------------------------------------------------
+const WithAttrs = styled.button.attrs({ type: 'button' })`
+  cursor: pointer;
+`
+export const _jsx_WithAttrs = <WithAttrs onClick={() => undefined} />
+
+const WithConfig = styled.div.withConfig({ displayName: 'Tagged' })`
+  display: flex;
+`
+export const _jsx_WithConfig = <WithConfig />
+
+// -----------------------------------------------------------------------------
+// `css\`...\`` returns a value that's interpolatable into another styled.
+// -----------------------------------------------------------------------------
+const tokens = css`
+  color: red;
+`
+const Composed = styled.div`
+  ${tokens};
+  margin: 4px;
+`
+export const _jsx_Composed = <Composed />
+
+// `css` is callable with template literal args.
+export type _css_callable = Expect<
+  IsNever<ReturnType<typeof css>> extends true ? false : true
+>
+
+// -----------------------------------------------------------------------------
+// `createGlobalStyle` returns a React component (no required props).
+// -----------------------------------------------------------------------------
+const Globals = createGlobalStyle`
+  body { margin: 0; }
+`
+export const _jsx_Globals = <Globals />
+
+// -----------------------------------------------------------------------------
+// `keyframes` is re-exported from styled-components.
+// -----------------------------------------------------------------------------
+const Anim = keyframes`
+  from { opacity: 0; }
+  to   { opacity: 1; }
+`
+const Animated = styled.div`
+  animation: ${Anim} 200ms linear;
+`
+export const _jsx_Animated = <Animated />
+
+// -----------------------------------------------------------------------------
+// Negative scenarios.
+// -----------------------------------------------------------------------------
+
+// `styled.div` without a template literal isn't callable.
+const _badStyled = (
+  // @ts-expect-error `styled.div` requires a tagged template (or string literal types via .attrs)
+  <styled.div />
+)
+void _badStyled
+
+// Bad attribute types on the wrapped element are rejected.
+const _badAttr = (
+  // @ts-expect-error `disabled` on a button is boolean, not string
+  <WithAttrs disabled="yes" />
+)
+void _badAttr

--- a/packages/styled-components/src/__type-tests__/x.test-d.tsx
+++ b/packages/styled-components/src/__type-tests__/x.test-d.tsx
@@ -1,0 +1,94 @@
+import * as React from 'react'
+import { x } from '../index'
+import type { Expect, Assignable, IsNever } from './_helpers'
+
+// -----------------------------------------------------------------------------
+// `x` is a record of styled tags. Every supported HTML element is callable.
+// -----------------------------------------------------------------------------
+export type _x_has_div = Expect<IsNever<typeof x.div> extends true ? false : true>
+export type _x_has_a = Expect<IsNever<typeof x.a> extends true ? false : true>
+export type _x_has_button = Expect<
+  IsNever<typeof x.button> extends true ? false : true
+>
+
+// JSX usage — these must type-check.
+export const _jsx_basic = <x.div />
+export const _jsx_with_html_attrs = (
+  <x.a href="https://example.com" rel="noopener" />
+)
+export const _jsx_with_system_props = <x.div m={2} p={1} display="flex" />
+export const _jsx_responsive_space = <x.div m={{ _: 1, md: 2, lg: 4 }} />
+export const _jsx_color = <x.div color="red" backgroundColor="#fff" />
+export const _jsx_complex = (
+  <x.button
+    px={2}
+    py={1}
+    color="white"
+    backgroundColor="blue"
+    onClick={(e) => {
+      // Event handler is typed.
+      const _t: React.MouseEvent<HTMLButtonElement> = e
+      void _t
+    }}
+  >
+    Click
+  </x.button>
+)
+
+// `as` prop swaps the underlying element. The runtime supports both
+// `as="a"` (string) and `as={Component}`.
+export const _jsx_as_string = <x.div as="a" href="https://example.com" />
+const _Custom: React.FC<{ label: string }> = (props) => (
+  <span>{props.label}</span>
+)
+export const _jsx_as_component = <x.div as={_Custom} label="hello" />
+
+// Children + ref forwarding work.
+export const _jsx_with_children = <x.div>hello</x.div>
+
+// -----------------------------------------------------------------------------
+// Negative scenarios — value-level.
+// -----------------------------------------------------------------------------
+
+// HTML attributes are strict on the underlying element.
+const _badHref = (
+  // @ts-expect-error `href` is a number — `x.a` requires `string`
+  <x.a href={42} />
+)
+void _badHref
+
+// Event handlers are typed against the underlying element.
+const _badHandler = (
+  <x.button
+    // @ts-expect-error onClick gets a MouseEvent, not a number
+    onClick={42}
+  />
+)
+void _badHandler
+
+// `m` accepts spacing; without theme augmentation `Space<ITheme>` widens to
+// `{}` (via `ThemeNamespaceValue`), so most non-nullish things pass. `null`
+// is the value-level case we can reliably negate.
+const _badM = (
+  // @ts-expect-error `null` is excluded by the `{}` arm of ThemeNamespaceValue
+  <x.div m={null} />
+)
+void _badM
+
+// `x.div` should not accept the `label` prop unless `as={SomeComponent}`
+// adds it. Note: this depends on styled-components' prop inference.
+const _badProp = (
+  // @ts-expect-error `label` is not an HTML attribute on a <div>
+  <x.div label="oops" />
+)
+void _badProp
+
+// -----------------------------------------------------------------------------
+// Assignability sanity — `x.div` is a valid JSX component type.
+// -----------------------------------------------------------------------------
+type _xdiv_is_jsx_component = Expect<
+  Assignable<
+    React.ElementType,
+    typeof x.div
+  >
+>

--- a/packages/styled-components/tsconfig.json
+++ b/packages/styled-components/tsconfig.json
@@ -1,6 +1,10 @@
 {
-  "include": ["src"],
-  "exclude": ["src/__type-tests__"],
+  "include": [
+    "src"
+  ],
+  "exclude": [
+    "src/__type-tests__"
+  ],
   "compilerOptions": {
     "strict": true,
     "noUnusedLocals": true,
@@ -12,6 +16,21 @@
     "esModuleInterop": true,
     "moduleResolution": "node",
     "jsx": "react",
-    "sourceMap": true
+    "sourceMap": true,
+    "baseUrl": ".",
+    "paths": {
+      "@xstyled/util": [
+        "../util/src"
+      ],
+      "@xstyled/prop-types": [
+        "../prop-types/src"
+      ],
+      "@xstyled/system": [
+        "../system/src"
+      ],
+      "@xstyled/core": [
+        "../core/src"
+      ]
+    }
   }
 }

--- a/packages/styled-components/tsconfig.json
+++ b/packages/styled-components/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "include": ["src"],
+  "exclude": ["src/__type-tests__"],
   "compilerOptions": {
     "strict": true,
     "noUnusedLocals": true,

--- a/packages/styled-components/tsconfig.types.json
+++ b/packages/styled-components/tsconfig.types.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src/__type-tests__"],
+  "exclude": [],
+  "compilerOptions": {
+    "noEmit": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "skipLibCheck": true
+  }
+}

--- a/packages/system/src/__type-tests__/_helpers.ts
+++ b/packages/system/src/__type-tests__/_helpers.ts
@@ -1,0 +1,29 @@
+/**
+ * Type-level test helpers. These files are excluded from the runtime build
+ * and from jest; they are only compiled by `yarn check:types` against the
+ * `tsconfig.types.json` project.
+ *
+ * Positive assertions use `Expect<Equal<...>>` or `Expect<Assignable<...>>`
+ * at the type level; negative assertions use `// @ts-expect-error` at the
+ * value level so the test fails if the rejection ever stops working.
+ */
+
+export type Expect<T extends true> = T
+
+export type Equal<A, B> = (<X>() => X extends A ? 1 : 2) extends <
+  X,
+>() => X extends B ? 1 : 2
+  ? true
+  : false
+
+export type NotEqual<A, B> = Equal<A, B> extends true ? false : true
+
+export type Assignable<T, V> = [V] extends [T] ? true : false
+
+export type NotAssignable<T, V> = Assignable<T, V> extends true ? false : true
+
+export type Extends<A, B> = A extends B ? true : false
+
+export type IsNever<T> = [T] extends [never] ? true : false
+
+export type IsAny<T> = 0 extends 1 & T ? true : false

--- a/packages/system/src/__type-tests__/colors.test-d.ts
+++ b/packages/system/src/__type-tests__/colors.test-d.ts
@@ -1,0 +1,77 @@
+import type { Color, ThemeColor } from '../styles/colors'
+import type { Expect, Assignable, NotAssignable } from './_helpers'
+
+interface MyTheme {
+  colors: {
+    primary: '#000'
+    secondary: '#fff'
+    danger: {
+      100: '#f00'
+      500: '#a00'
+      default: '#900'
+    }
+  }
+}
+
+// -----------------------------------------------------------------------------
+// ThemeColor surfaces every leaf path.
+// -----------------------------------------------------------------------------
+export type _theme_primary = Expect<Assignable<ThemeColor<MyTheme>, 'primary'>>
+export type _theme_secondary = Expect<
+  Assignable<ThemeColor<MyTheme>, 'secondary'>
+>
+export type _theme_danger100 = Expect<
+  Assignable<ThemeColor<MyTheme>, 'danger.100'>
+>
+export type _theme_danger_default = Expect<
+  Assignable<ThemeColor<MyTheme>, 'danger.default'>
+>
+
+// And refuses arbitrary strings / bare parents (#413).
+export type _theme_no_typo = Expect<NotAssignable<ThemeColor<MyTheme>, 'primry'>>
+export type _theme_no_bare_parent = Expect<
+  NotAssignable<ThemeColor<MyTheme>, 'danger'>
+>
+
+// -----------------------------------------------------------------------------
+// Color is the union of theme paths + CSS color literals.
+// -----------------------------------------------------------------------------
+export type _color_theme = Expect<Assignable<Color<MyTheme>, 'primary'>>
+export type _color_named = Expect<Assignable<Color<MyTheme>, 'red'>>
+export type _color_currentcolor = Expect<
+  Assignable<Color<MyTheme>, 'currentcolor'>
+>
+export type _color_hex_short = Expect<Assignable<Color<MyTheme>, '#abc'>>
+export type _color_hex_long = Expect<Assignable<Color<MyTheme>, '#aabbcc'>>
+export type _color_rgb = Expect<Assignable<Color<MyTheme>, 'rgb(0, 0, 0)'>>
+export type _color_rgba = Expect<Assignable<Color<MyTheme>, 'rgba(0, 0, 0, 0.5)'>>
+export type _color_hsl = Expect<Assignable<Color<MyTheme>, 'hsl(0, 0%, 0%)'>>
+
+// CSS variables / arbitrary fn() are intentionally permitted via FnColor.
+export type _color_var = Expect<Assignable<Color<MyTheme>, 'var(--token)'>>
+
+// -----------------------------------------------------------------------------
+// Negative scenarios — value-level @ts-expect-error.
+// These rely on the contextual type from the annotation.
+// -----------------------------------------------------------------------------
+
+// Token typos must be rejected.
+// @ts-expect-error 'primry' is not a theme color or CSS named color
+const _badTypo: Color<MyTheme> = 'primry'
+
+// Bare parent is not a leaf path (#413).
+// @ts-expect-error 'danger' is a namespace, not a leaf color
+const _badBareParent: Color<MyTheme> = 'danger'
+
+// Made-up nested paths.
+// @ts-expect-error 'danger.999' is not a key in MyTheme.danger
+const _badNestedPath: Color<MyTheme> = 'danger.999'
+
+// Numbers should not assign to a string-typed Color.
+// @ts-expect-error number is not a Color
+const _badNumber: Color<MyTheme> = 123
+
+void _badTypo
+void _badBareParent
+void _badNestedPath
+void _badNumber

--- a/packages/system/src/__type-tests__/perf.test-d.ts
+++ b/packages/system/src/__type-tests__/perf.test-d.ts
@@ -1,0 +1,136 @@
+/**
+ * Heavy-instantiation type test. Not asserting anything specific; it exists
+ * so `tsc --extendedDiagnostics` (run via `yarn bench:types`) reports
+ * realistic numbers — i.e. the cost of resolving Color/Space against a
+ * sizeable theme. If somebody regresses union-explosion behavior (#429),
+ * the Instantiations counter on this file will spike.
+ */
+import type { Color } from '../styles/colors'
+import type { Space } from '../styles/space'
+import type { SystemProp } from '../types'
+
+// 60 top-level color tokens plus a couple of nested scales — comparable to a
+// real-world Tailwind-ish theme.
+interface BigTheme {
+  colors: {
+    black: '#000'
+    white: '#fff'
+    transparent: 'transparent'
+    'gray-50': '#f9fafb'
+    'gray-100': '#f3f4f6'
+    'gray-200': '#e5e7eb'
+    'gray-300': '#d1d5db'
+    'gray-400': '#9ca3af'
+    'gray-500': '#6b7280'
+    'gray-600': '#4b5563'
+    'gray-700': '#374151'
+    'gray-800': '#1f2937'
+    'gray-900': '#111827'
+    'red-50': '#fef2f2'
+    'red-100': '#fee2e2'
+    'red-200': '#fecaca'
+    'red-300': '#fca5a5'
+    'red-400': '#f87171'
+    'red-500': '#ef4444'
+    'red-600': '#dc2626'
+    'red-700': '#b91c1c'
+    'red-800': '#991b1b'
+    'red-900': '#7f1d1d'
+    'yellow-50': '#fefce8'
+    'yellow-100': '#fef9c3'
+    'yellow-200': '#fef08a'
+    'yellow-300': '#fde047'
+    'yellow-400': '#facc15'
+    'yellow-500': '#eab308'
+    'yellow-600': '#ca8a04'
+    'yellow-700': '#a16207'
+    'yellow-800': '#854d0e'
+    'yellow-900': '#713f12'
+    'green-50': '#f0fdf4'
+    'green-100': '#dcfce7'
+    'green-200': '#bbf7d0'
+    'green-300': '#86efac'
+    'green-400': '#4ade80'
+    'green-500': '#22c55e'
+    'green-600': '#16a34a'
+    'green-700': '#15803d'
+    'green-800': '#166534'
+    'green-900': '#14532d'
+    'blue-50': '#eff6ff'
+    'blue-100': '#dbeafe'
+    'blue-200': '#bfdbfe'
+    'blue-300': '#93c5fd'
+    'blue-400': '#60a5fa'
+    'blue-500': '#3b82f6'
+    'blue-600': '#2563eb'
+    'blue-700': '#1d4ed8'
+    'blue-800': '#1e40af'
+    'blue-900': '#1e3a8a'
+    // Plus a nested scale to exercise the recursive branch.
+    brand: {
+      primary: '#5b21b6'
+      secondary: '#6d28d9'
+      tertiary: '#7c3aed'
+      light: '#a78bfa'
+      dark: '#4c1d95'
+    }
+  }
+  space: {
+    0: 0
+    0.5: '2px'
+    1: '4px'
+    2: '8px'
+    3: '12px'
+    4: '16px'
+    5: '20px'
+    6: '24px'
+    8: '32px'
+    10: '40px'
+    12: '48px'
+    16: '64px'
+    20: '80px'
+    24: '96px'
+    32: '128px'
+    40: '160px'
+    48: '192px'
+    56: '224px'
+    64: '256px'
+  }
+  screens: {
+    sm: 640
+    md: 768
+    lg: 1024
+    xl: 1280
+    '2xl': 1536
+  }
+  states: {
+    _: null
+    hover: '&:hover'
+    focus: '&:focus'
+    active: '&:active'
+    disabled: '&:disabled'
+  }
+}
+
+// Force materialization of the heavy generic types.
+type ColorProp = SystemProp<Color<BigTheme>, BigTheme>
+type SpaceProp = SystemProp<Space<BigTheme>, BigTheme>
+
+declare const _colorAtRoot: ColorProp
+declare const _colorAtBreakpoint: ColorProp
+declare const _spaceAtRoot: SpaceProp
+
+// Touch concrete responsive shapes so the responsive-prop variant is
+// actually instantiated (not just declared).
+const _r1: ColorProp = { sm: 'red-500', md: 'blue-500', lg: 'brand.primary' }
+const _r2: SpaceProp = { sm: 1, md: 2, lg: 4 }
+const _r3: ColorProp = 'gray-900'
+const _r4: SpaceProp = '12px'
+
+void _colorAtRoot
+void _colorAtBreakpoint
+void _spaceAtRoot
+void _r1
+void _r2
+void _r3
+void _r4

--- a/packages/system/src/__type-tests__/perf.test-d.ts
+++ b/packages/system/src/__type-tests__/perf.test-d.ts
@@ -97,6 +97,7 @@ interface BigTheme {
     64: '256px'
   }
   screens: {
+    _: 0
     sm: 640
     md: 768
     lg: 1024
@@ -121,9 +122,10 @@ declare const _colorAtBreakpoint: ColorProp
 declare const _spaceAtRoot: SpaceProp
 
 // Touch concrete responsive shapes so the responsive-prop variant is
-// actually instantiated (not just declared).
-const _r1: ColorProp = { sm: 'red-500', md: 'blue-500', lg: 'brand.primary' }
-const _r2: SpaceProp = { sm: 1, md: 2, lg: 4 }
+// actually instantiated (not just declared). `_` is the base/no-breakpoint
+// key (provided by `screens._`); `md`/`lg` are real media keys.
+const _r1: ColorProp = { _: 'red-500', md: 'blue-500', lg: 'brand.primary' }
+const _r2: SpaceProp = { _: 1, md: 2, lg: 4 }
 const _r3: ColorProp = 'gray-900'
 const _r4: SpaceProp = '12px'
 

--- a/packages/system/src/__type-tests__/responsive.test-d.ts
+++ b/packages/system/src/__type-tests__/responsive.test-d.ts
@@ -1,0 +1,81 @@
+import type { ThemeProp, SystemProp, ThemeVariants } from '../types'
+import type {
+  Expect,
+  Assignable,
+  NotAssignable,
+} from './_helpers'
+
+// -----------------------------------------------------------------------------
+// `_` belongs to `screens` (the "no breakpoint" entry), not `states`.
+// `ThemeVariants` is `screens & Omit<states, '_'>` — the Omit avoids the
+// intersection between `screens._: number` and `states._: null` colliding;
+// `_` itself still flows through from `screens`.
+// -----------------------------------------------------------------------------
+interface TightTheme {
+  screens: {
+    _: 0
+    sm: 640
+    md: 768
+    lg: 1024
+  }
+  states: {
+    _: null
+    hover: '&:hover'
+    focus: '&:focus'
+  }
+}
+
+// `_`, breakpoints, and states are all present.
+export type _variants_has_base = Expect<
+  Assignable<keyof ThemeVariants<TightTheme>, '_'>
+>
+export type _variants_has_breakpoint = Expect<
+  Assignable<keyof ThemeVariants<TightTheme>, 'md'>
+>
+export type _variants_has_state = Expect<
+  Assignable<keyof ThemeVariants<TightTheme>, 'hover'>
+>
+
+// But not made-up keys.
+export type _variants_no_bogus = Expect<
+  NotAssignable<keyof ThemeVariants<TightTheme>, 'lolwut'>
+>
+
+// -----------------------------------------------------------------------------
+// `SystemProp<TType, T>` is either a bare value or a `ThemeProp` map.
+// The map permits the base `_` key when the theme types it via `screens`.
+// -----------------------------------------------------------------------------
+const _bare: SystemProp<string, TightTheme> = 'red'
+const _responsive: SystemProp<string, TightTheme> = {
+  _: 'red',
+  md: 'blue',
+  lg: 'green',
+  hover: 'orange',
+}
+const _nested: SystemProp<string, TightTheme> = {
+  _: 'red',
+  md: { hover: 'orange', focus: 'yellow' },
+}
+void _bare
+void _responsive
+void _nested
+
+// Object shape rejects unknown keys.
+// @ts-expect-error 'never-bp' is not a known breakpoint/state
+const _badKey: ThemeProp<string, TightTheme> = { 'never-bp': 'red' }
+void _badKey
+
+// -----------------------------------------------------------------------------
+// When the theme is *not* tightly typed (the default `ITheme` shape), the
+// type stays permissive — value-level mistakes don't get rejected. This is
+// by design and an important property to lock in: tightening the theme is
+// what unlocks the strict checks. Test it indirectly via `ITheme`.
+// -----------------------------------------------------------------------------
+import type { ITheme } from '../types'
+
+const _loose: SystemProp<string, ITheme> = {
+  _: 'red',
+  anyKey: 'green',
+  fooBar: 'blue',
+}
+void _loose

--- a/packages/system/src/__type-tests__/space.test-d.ts
+++ b/packages/system/src/__type-tests__/space.test-d.ts
@@ -1,0 +1,50 @@
+import type { Space, ThemeSpace } from '../styles/space'
+import type { Pixel } from '../styles/units'
+import type { Expect, Assignable, IsAny } from './_helpers'
+
+interface MyTheme {
+  space: {
+    sm: '4px'
+    md: '8px'
+    lg: '16px'
+    1.5: '6px'
+  }
+}
+
+// -----------------------------------------------------------------------------
+// Pixel: the `(string & {}) | (number & {})` pattern from #428.
+// It must accept any string or number but must NOT widen to `any`
+// (otherwise IntelliSense completions get clobbered).
+// -----------------------------------------------------------------------------
+export type _pixel_string = Expect<Assignable<Pixel, '12px'>>
+export type _pixel_number = Expect<Assignable<Pixel, 12>>
+export type _pixel_not_any = Expect<IsAny<Pixel> extends true ? false : true>
+
+// -----------------------------------------------------------------------------
+// ThemeSpace surfaces the configured tokens, including numeric ones (#413).
+// Note: `ThemeNamespaceValue` intentionally unions with `{}` so style props
+// stay permissive of raw CSS values — that means we can assert tokens *can*
+// be assigned, but cannot assert that arbitrary strings are rejected at
+// the `ThemeSpace` level. The `Pixel` part is what stays strict-ish.
+// -----------------------------------------------------------------------------
+export type _space_sm = Expect<Assignable<ThemeSpace<MyTheme>, 'sm'>>
+export type _space_md = Expect<Assignable<ThemeSpace<MyTheme>, 'md'>>
+export type _space_numeric = Expect<Assignable<ThemeSpace<MyTheme>, 1.5>>
+
+// -----------------------------------------------------------------------------
+// Space accepts theme tokens AND raw pixel-ish values.
+// -----------------------------------------------------------------------------
+export type _space_token = Expect<Assignable<Space<MyTheme>, 'md'>>
+export type _space_px_string = Expect<Assignable<Space<MyTheme>, '24px'>>
+export type _space_number = Expect<Assignable<Space<MyTheme>, 24>>
+
+// -----------------------------------------------------------------------------
+// Negative scenarios — value-level rejection.
+// `ThemeNamespaceValue` intentionally unions with `{}`, so `Space<T>`
+// accepts most non-nullish values (booleans, arrays, plain objects).
+// `null` and `undefined` are the only things the type excludes.
+// -----------------------------------------------------------------------------
+
+// @ts-expect-error null is excluded by the `{}` arm of ThemeNamespaceValue
+const _badNull: Space<MyTheme> = null
+void _badNull

--- a/packages/system/src/__type-tests__/synthesized-path.test-d.ts
+++ b/packages/system/src/__type-tests__/synthesized-path.test-d.ts
@@ -1,0 +1,92 @@
+import type { SynthesizedPath } from '../types'
+import type {
+  Expect,
+  Equal,
+  Assignable,
+  IsNever,
+  NotAssignable,
+} from './_helpers'
+
+// -----------------------------------------------------------------------------
+// Flat shape
+// -----------------------------------------------------------------------------
+type Flat = { primary: '#fff'; secondary: '#000' }
+
+// Result is a union of the keys as string literals.
+export type _flatExact = Expect<
+  Equal<SynthesizedPath<Flat>, 'primary' | 'secondary'>
+>
+
+// -----------------------------------------------------------------------------
+// Nested objects produce dotted paths
+// -----------------------------------------------------------------------------
+type Nested = {
+  blue: { 50: '#a'; 100: '#b' }
+  red: { default: '#c'; 500: '#d' }
+}
+
+// Each leaf produces a path; numeric leaves stringify cleanly (#413).
+export type _nestedHas = Expect<
+  Assignable<SynthesizedPath<Nested>, 'blue.50' | 'blue.100'>
+>
+export type _nestedHasDefault = Expect<
+  Assignable<SynthesizedPath<Nested>, 'red.default' | 'red.500'>
+>
+
+// And the union does not silently include the bare parent keys.
+export type _nestedNoBareParent = Expect<
+  NotAssignable<SynthesizedPath<Nested>, 'blue'>
+>
+
+// -----------------------------------------------------------------------------
+// Numeric-only keys at the root (#413 regression scenario)
+// -----------------------------------------------------------------------------
+type NumericRoot = { 1: '#a'; 2: '#b' }
+
+// Numeric keys at the root should yield string-literal paths, not `never`.
+export type _numericRootHas1 = Expect<
+  Assignable<SynthesizedPath<NumericRoot>, '1'>
+>
+export type _numericRootHas2 = Expect<
+  Assignable<SynthesizedPath<NumericRoot>, '2'>
+>
+export type _numericRootNotEmpty = Expect<
+  IsNever<SynthesizedPath<NumericRoot>> extends true ? false : true
+>
+
+// -----------------------------------------------------------------------------
+// Deep nesting respects a sane depth so very-deep themes do not blow up the
+// instantiation counter (#429 "union type too complex to represent").
+// -----------------------------------------------------------------------------
+type Deep10 = {
+  a: { b: { c: { d: { e: { f: { g: { h: { i: { j: 'leaf' } } } } } } } } }
+}
+
+// We only require that some path is produced (i.e. the type stays usable).
+// Whether the depth guard kicks in at exactly N levels is an implementation
+// detail; what matters is the result is never `never` and is assignable to
+// `string`.
+export type _deepUsable = Expect<Assignable<string, SynthesizedPath<Deep10>>>
+export type _deepNotNever = Expect<
+  IsNever<SynthesizedPath<Deep10>> extends true ? false : true
+>
+
+// -----------------------------------------------------------------------------
+// Negative scenarios — the produced paths must reject arbitrary strings.
+// -----------------------------------------------------------------------------
+
+// Correct paths assign fine.
+const _ok1: SynthesizedPath<Nested> = 'blue.50'
+const _ok2: SynthesizedPath<Nested> = 'red.default'
+void _ok1
+void _ok2
+
+// @ts-expect-error 'blue.999' is not a real path in the theme
+const _bad1: SynthesizedPath<Nested> = 'blue.999'
+// @ts-expect-error typo
+const _bad2: SynthesizedPath<Nested> = 'bleu.50'
+// @ts-expect-error bare parent is not a leaf path
+const _bad3: SynthesizedPath<Nested> = 'blue'
+void _bad1
+void _bad2
+void _bad3

--- a/packages/system/src/__type-tests__/th.test-d.ts
+++ b/packages/system/src/__type-tests__/th.test-d.ts
@@ -1,0 +1,103 @@
+import { th } from '../th'
+import { compose, style } from '../style'
+import { margin, padding } from '../styles/space'
+import type {
+  StyleGenerator,
+  StyleGeneratorProps,
+  StyleGeneratorPropsConcat,
+  Props,
+  Theme,
+  CSSScalar,
+} from '../types'
+import type { Expect, Equal, Assignable, IsNever } from './_helpers'
+
+// -----------------------------------------------------------------------------
+// `th` is callable with a path (string | number) and an optional default.
+// It returns a function of `props` that returns a `CSSScalar`.
+// -----------------------------------------------------------------------------
+const _thCall = th('colors.primary')
+const _thWithDefault = th('colors.primary', '#000')
+const _thNumeric = th(1)
+
+type _thReturnIsFn = Expect<
+  Equal<ReturnType<typeof th>, (props: Props<Theme>) => CSSScalar>
+>
+
+void _thCall
+void _thWithDefault
+void _thNumeric
+
+// `th.color`, `th.space`, etc. are exposed as the underlying ThemeGetters.
+const _thColor = th.color('primary')
+const _thSpace = th.space(2)
+const _thRadius = th.radius('md')
+void _thColor
+void _thSpace
+void _thRadius
+
+// `th.color` and `th.space` should NOT be `never` (proves the dynamic
+// attachment in `th.ts` types correctly via the `ThGetters` interface).
+export type _thColorExists = Expect<
+  IsNever<typeof th.color> extends true ? false : true
+>
+export type _thSpaceExists = Expect<
+  IsNever<typeof th.space> extends true ? false : true
+>
+
+// `th.color(value)` itself returns a function of props (`ThemeGetter`).
+const _thColorApplied = th.color('primary')({ theme: {} })
+type _thColorAppliedIsScalar = Expect<
+  Equal<typeof _thColorApplied, CSSScalar>
+>
+void _thColorApplied
+
+// -----------------------------------------------------------------------------
+// `compose()` flows props through. Both overloads carry the props.
+// -----------------------------------------------------------------------------
+interface FooProps {
+  foo?: string
+}
+interface BarProps {
+  bar?: number
+}
+
+const fooGen = style<FooProps>({ prop: 'foo', css: 'color' })
+const barGen = style<BarProps>({ prop: 'bar', css: 'fontSize' })
+
+type _fooPropsExtracted = Expect<
+  Equal<StyleGeneratorProps<typeof fooGen>, FooProps>
+>
+type _barPropsExtracted = Expect<
+  Equal<StyleGeneratorProps<typeof barGen>, BarProps>
+>
+
+// `compose()` should union (`&`) the props of every generator it composes.
+const composed = compose(fooGen, barGen)
+type ComposedProps = StyleGeneratorProps<typeof composed>
+
+// FooProps and BarProps must both be reachable through the composed generator.
+export type _composedHasFoo = Expect<Assignable<ComposedProps, { foo: string }>>
+export type _composedHasBar = Expect<Assignable<ComposedProps, { bar: number }>>
+
+// `StyleGeneratorPropsConcat` directly composes a tuple of generators.
+type _concat = Expect<
+  Equal<
+    StyleGeneratorPropsConcat<[typeof fooGen, typeof barGen]>,
+    FooProps & BarProps & unknown
+  >
+>
+
+// -----------------------------------------------------------------------------
+// `style()` returns a `StyleGenerator`, including for the array form.
+// -----------------------------------------------------------------------------
+const arrayProp = style({ prop: ['margin', 'm'], css: 'margin' })
+type _isGen = Expect<
+  Assignable<StyleGenerator, typeof arrayProp>
+>
+
+// `margin` and `padding` are pre-built generators; composing them yields the
+// merged props.
+const spaceMixed = compose(margin, padding)
+type _spaceMixedProps = StyleGeneratorProps<typeof spaceMixed>
+// We don't pin the exact shape; we just require it stays a record-ish.
+export type _spaceMixedExtends = Expect<Assignable<object, _spaceMixedProps>>

--- a/packages/system/src/styles/index.test.ts
+++ b/packages/system/src/styles/index.test.ts
@@ -15,7 +15,7 @@ describe('#system', () => {
       spaceY: { _: 3, sm: 0 },
       spaceX: { sm: 4 },
     })
-    const keys = Object.keys(res)
+    const keys = Object.keys(res ?? {})
     expect(keys).toEqual([
       'display',
       '& > :not([hidden]) ~ :not([hidden])',

--- a/packages/system/src/types.ts
+++ b/packages/system/src/types.ts
@@ -115,17 +115,37 @@ export interface TransformValue {
   ): CSSScalar
 }
 
+// Bounded-depth tail for `SynthesizedPath`. Each recursive instantiation
+// peels one element off the front; reaching `never` stops the recursion
+// and the type widens to `string` so deep themes still type-check
+// without producing an unrepresentable union (#429).
+type _SynthesizedPathDepth = [never, 0, 1, 2, 3, 4, 5, 6]
+
 /**
  * Recursively explores a given object and creates a union of the deep paths
  * leading to primitive values (non-objects.)
+ *
+ * Notes:
+ *  - Numeric keys are preserved as string-form path segments so themes like
+ *    `{ blue: { 50: '#…' } }` resolve to `'blue.50'` (#413).
+ *  - Recursion is depth-bounded; beyond `D = 6` the result widens to `string`
+ *    to keep TypeScript happy on very-deep themes (#429).
  */
-export type SynthesizedPath<T extends Record<string, unknown>> = {
-  [P in keyof T]: P extends string
-    ? T[P] extends Record<string, unknown>
-      ? `${P}.${SynthesizedPath<T[P]>}`
-      : P
-    : never
-}[keyof T]
+export type SynthesizedPath<
+  T,
+  D extends number = 6,
+> = [D] extends [never]
+  ? string
+  : T extends Record<string | number, unknown>
+  ? {
+      [P in keyof T & (string | number)]: T[P] extends Record<
+        string | number,
+        unknown
+      >
+        ? `${P}.${SynthesizedPath<T[P], _SynthesizedPathDepth[D]>}`
+        : `${P}`
+    }[keyof T & (string | number)]
+  : never
 
 export type ThemeNamespaceValue<K extends string, T extends ITheme> =
   | NamespaceType<T[K]>

--- a/packages/system/src/types.ts
+++ b/packages/system/src/types.ts
@@ -118,8 +118,11 @@ export interface TransformValue {
 // Bounded-depth tail for `SynthesizedPath`. Each recursive instantiation
 // peels one element off the front; reaching `never` stops the recursion
 // and the type widens to `string` so deep themes still type-check
-// without producing an unrepresentable union (#429).
-type _SynthesizedPathDepth = [never, 0, 1, 2, 3, 4, 5, 6]
+// without producing an unrepresentable union (#429). The `...never[]`
+// rest guards against an explicit out-of-range custom depth such as
+// `SynthesizedPath<T, 42>`: any index past the listed slots returns
+// `never`, which the next recursion treats as the stop condition.
+type _SynthesizedPathDepth = [never, 0, 1, 2, 3, 4, 5, 6, ...never[]]
 
 /**
  * Recursively explores a given object and creates a union of the deep paths

--- a/packages/system/tsconfig.aug.json
+++ b/packages/system/tsconfig.aug.json
@@ -1,6 +1,6 @@
 {
   "extends": "./tsconfig.json",
-  "include": ["type-tests-aug", "src/types.ts", "src/styles/colors.ts", "src/styles/space.ts", "src/styles/units.ts", "src/style.ts", "src/theme.ts", "src/cache.ts", "src/transformers.ts", "src/unit.ts"],
+  "include": ["type-tests-aug"],
   "exclude": [],
   "compilerOptions": {
     "noEmit": true,

--- a/packages/system/tsconfig.aug.json
+++ b/packages/system/tsconfig.aug.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["type-tests-aug", "src/types.ts", "src/styles/colors.ts", "src/styles/space.ts", "src/styles/units.ts", "src/style.ts", "src/theme.ts", "src/cache.ts", "src/transformers.ts", "src/unit.ts"],
+  "exclude": [],
+  "compilerOptions": {
+    "noEmit": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "skipLibCheck": true
+  }
+}

--- a/packages/system/tsconfig.aug.json
+++ b/packages/system/tsconfig.aug.json
@@ -6,6 +6,10 @@
     "noEmit": true,
     "noUnusedLocals": false,
     "noUnusedParameters": false,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "baseUrl": ".",
+    "paths": {
+      "@xstyled/util": ["../util/src"]
+    }
   }
 }

--- a/packages/system/tsconfig.json
+++ b/packages/system/tsconfig.json
@@ -1,6 +1,10 @@
 {
-  "include": ["src"],
-  "exclude": ["src/__type-tests__"],
+  "include": [
+    "src"
+  ],
+  "exclude": [
+    "src/__type-tests__"
+  ],
   "compilerOptions": {
     "strict": true,
     "noUnusedLocals": true,
@@ -12,6 +16,21 @@
     "esModuleInterop": true,
     "moduleResolution": "node",
     "jsx": "react",
-    "sourceMap": true
+    "sourceMap": true,
+    "baseUrl": ".",
+    "paths": {
+      "@xstyled/util": [
+        "../util/src"
+      ],
+      "@xstyled/prop-types": [
+        "../prop-types/src"
+      ],
+      "@xstyled/system": [
+        "../system/src"
+      ],
+      "@xstyled/core": [
+        "../core/src"
+      ]
+    }
   }
 }

--- a/packages/system/tsconfig.json
+++ b/packages/system/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "include": ["src"],
+  "exclude": ["src/__type-tests__"],
   "compilerOptions": {
     "strict": true,
     "noUnusedLocals": true,

--- a/packages/system/tsconfig.types.json
+++ b/packages/system/tsconfig.types.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src/__type-tests__"],
+  "exclude": [],
+  "compilerOptions": {
+    "noEmit": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "skipLibCheck": true
+  }
+}

--- a/packages/system/type-tests-aug/augmentation.test-d.ts
+++ b/packages/system/type-tests-aug/augmentation.test-d.ts
@@ -1,6 +1,7 @@
 /**
  * Pins down how a downstream consumer is meant to specialise xstyled's
- * `Theme` via module augmentation (#344 / #417 / #418). The contract:
+ * `Theme` via module augmentation (#344 / #417 / #418). The contract,
+ * as documented at website/pages/docs/core-concepts/typescript.mdx, is:
  *
  *   declare module '@xstyled/system' {
  *     export interface Theme {
@@ -8,23 +9,24 @@
  *     }
  *   }
  *
- * After augmentation:
- *  - `Color` (no generic) narrows to the consumer's tokens + CSS color
- *    literals.
- *  - Typos are rejected, IntelliSense surfaces the configured tokens.
+ * This file mirrors that exactly — importing from `@xstyled/system` and
+ * augmenting `@xstyled/system` — so the test exercises the same code path
+ * a real consumer hits. The `tsconfig.aug.json` project owns this file,
+ * which keeps the project-wide augmentation from leaking into the normal
+ * src compile.
  *
- * Because `declare module` is project-wide we keep this file under its own
- * tsconfig (`tsconfig.aug.json`) — the augmented `Theme` does NOT leak into
- * the normal src compile.
+ * Requires `yarn build` to have produced `packages/system/dist/index.d.ts`
+ * first (the workspace symlink `node_modules/@xstyled/system` resolves
+ * through `package.json#types`); `yarn check:types` in CI runs after
+ * `yarn build`, so this is satisfied.
  */
-import type { Color, ThemeColor } from '../src/styles/colors'
-import type { Space, ThemeSpace } from '../src/styles/space'
+import type { Color, ThemeColor, Space, ThemeSpace } from '@xstyled/system'
 
 type Expect<T extends true> = T
 type Assignable<T, V> = [V] extends [T] ? true : false
 type NotAssignable<T, V> = Assignable<T, V> extends true ? false : true
 
-declare module '../src/types' {
+declare module '@xstyled/system' {
   interface Theme {
     colors: {
       brandPrimary: '#5b21b6'

--- a/packages/system/type-tests-aug/augmentation.test-d.ts
+++ b/packages/system/type-tests-aug/augmentation.test-d.ts
@@ -1,0 +1,80 @@
+/**
+ * Pins down how a downstream consumer is meant to specialise xstyled's
+ * `Theme` via module augmentation (#344 / #417 / #418). The contract:
+ *
+ *   declare module '@xstyled/system' {
+ *     export interface Theme {
+ *       colors: { ... }
+ *     }
+ *   }
+ *
+ * After augmentation:
+ *  - `Color` (no generic) narrows to the consumer's tokens + CSS color
+ *    literals.
+ *  - Typos are rejected, IntelliSense surfaces the configured tokens.
+ *
+ * Because `declare module` is project-wide we keep this file under its own
+ * tsconfig (`tsconfig.aug.json`) — the augmented `Theme` does NOT leak into
+ * the normal src compile.
+ */
+import type { Color, ThemeColor } from '../src/styles/colors'
+import type { Space, ThemeSpace } from '../src/styles/space'
+
+type Expect<T extends true> = T
+type Assignable<T, V> = [V] extends [T] ? true : false
+type NotAssignable<T, V> = Assignable<T, V> extends true ? false : true
+
+declare module '../src/types' {
+  interface Theme {
+    colors: {
+      brandPrimary: '#5b21b6'
+      brandSecondary: '#7c3aed'
+      shades: {
+        100: '#eee'
+        500: '#888'
+        900: '#222'
+      }
+    }
+    space: {
+      tight: 4
+      cosy: 8
+      roomy: 16
+    }
+  }
+}
+
+// -----------------------------------------------------------------------------
+// `Color` (no generic) reflects the augmentation.
+// -----------------------------------------------------------------------------
+export type _aug_color_brand = Expect<Assignable<Color, 'brandPrimary'>>
+export type _aug_color_nested = Expect<Assignable<Color, 'shades.500'>>
+export type _aug_themecolor_all = Expect<
+  Assignable<
+    ThemeColor,
+    'brandPrimary' | 'brandSecondary' | 'shades.100' | 'shades.500' | 'shades.900'
+  >
+>
+
+// CSS-level colors still come through.
+export type _aug_color_still_named = Expect<Assignable<Color, 'red'>>
+export type _aug_color_still_hex = Expect<Assignable<Color, '#abcdef'>>
+
+// ThemeColor is strict — typos rejected.
+export type _aug_themecolor_no_typo = Expect<
+  NotAssignable<ThemeColor, 'brandPrimary-typo'>
+>
+export type _aug_themecolor_no_unknown = Expect<
+  NotAssignable<ThemeColor, 'doesNotExist'>
+>
+
+// Value-level rejection.
+// @ts-expect-error 'brandTertiary' is not in the augmented theme
+const _badAugColor: Color = 'brandTertiary'
+void _badAugColor
+
+// -----------------------------------------------------------------------------
+// `Space` reflects the augmentation as well.
+// -----------------------------------------------------------------------------
+export type _aug_space_token = Expect<Assignable<ThemeSpace, 'tight'>>
+export type _aug_space_cosy = Expect<Assignable<Space, 'cosy'>>
+export type _aug_space_raw = Expect<Assignable<Space, '24px'>>

--- a/packages/util/src/__type-tests__/_helpers.ts
+++ b/packages/util/src/__type-tests__/_helpers.ts
@@ -1,0 +1,11 @@
+export type Expect<T extends true> = T
+
+export type Equal<A, B> = (<X>() => X extends A ? 1 : 2) extends <
+  X,
+>() => X extends B ? 1 : 2
+  ? true
+  : false
+
+export type Assignable<T, V> = [V] extends [T] ? true : false
+export type NotAssignable<T, V> = Assignable<T, V> extends true ? false : true
+export type IsNever<T> = [T] extends [never] ? true : false

--- a/packages/util/src/__type-tests__/predicates.test-d.ts
+++ b/packages/util/src/__type-tests__/predicates.test-d.ts
@@ -1,0 +1,138 @@
+import {
+  is,
+  num,
+  string,
+  obj,
+  func,
+  negative,
+  assign,
+  merge,
+  omit,
+  cascade,
+} from '../index'
+import type { Path, Props, ITheme } from '../types'
+import type { Expect, Equal, Assignable, NotAssignable } from './_helpers'
+
+// -----------------------------------------------------------------------------
+// Path / ITheme / Props are the public type surface.
+// -----------------------------------------------------------------------------
+export type _path_string = Expect<Assignable<Path, 'colors.primary'>>
+export type _path_number = Expect<Assignable<Path, 1>>
+export type _path_no_bool = Expect<NotAssignable<Path, true>>
+export type _path_no_object = Expect<NotAssignable<Path, { a: 1 }>>
+
+// `Props` defaults to `Props<ITheme>` and allows arbitrary string-keyed values.
+export type _props_default = Expect<Assignable<Props, { foo: 1; bar: 'x' }>>
+
+// -----------------------------------------------------------------------------
+// `is(v)` narrows out `null | undefined`.
+// -----------------------------------------------------------------------------
+{
+  const v: string | null | undefined = 'x' as string | null | undefined
+  if (is(v)) {
+    type _t = Expect<Equal<typeof v, string>>
+    void (null as unknown as _t)
+  }
+}
+
+// `is(v)` on a non-nullable input doesn't widen.
+{
+  const v: 1 | 2 | 3 = 1 as 1 | 2 | 3
+  if (is(v)) {
+    type _t = Expect<Equal<typeof v, 1 | 2 | 3>>
+    void (null as unknown as _t)
+  }
+}
+
+// -----------------------------------------------------------------------------
+// `num(v)` narrows to `number`.
+// -----------------------------------------------------------------------------
+{
+  const v: unknown = 1
+  if (num(v)) {
+    type _t = Expect<Equal<typeof v, number>>
+    void (null as unknown as _t)
+  }
+}
+
+// -----------------------------------------------------------------------------
+// `string(v)` narrows to non-empty `string`.
+// -----------------------------------------------------------------------------
+{
+  const v: unknown = 'x'
+  if (string(v)) {
+    type _t = Expect<Equal<typeof v, Exclude<string, ''>>>
+    void (null as unknown as _t)
+  }
+}
+
+// -----------------------------------------------------------------------------
+// `obj`, `func`, `negative` narrow correctly.
+// -----------------------------------------------------------------------------
+{
+  const v: unknown = {}
+  if (obj(v)) {
+    // obj narrows to a plain object type — at minimum it must be a record-like.
+    type _t = Expect<Assignable<object, typeof v>>
+    void (null as unknown as _t)
+  }
+}
+
+{
+  const v: unknown = () => null
+  if (func(v)) {
+    // eslint-disable-next-line @typescript-eslint/ban-types
+    type _t = Expect<Assignable<Function, typeof v>>
+    void (null as unknown as _t)
+  }
+}
+
+{
+  const v: unknown = -1
+  if (negative(v)) {
+    type _t = Expect<Equal<typeof v, number>>
+    void (null as unknown as _t)
+  }
+}
+
+// -----------------------------------------------------------------------------
+// `assign` / `merge` produce intersection types of source and target.
+// -----------------------------------------------------------------------------
+{
+  const result = assign({ a: 1 }, { b: 'x' })
+  type _t = Expect<Equal<typeof result, { a: number } & { b: string }>>
+  void (null as unknown as _t)
+}
+
+{
+  const result = merge({ a: 1 }, { b: 'x' })
+  type _t = Expect<Equal<typeof result, { a: number } & { b: string }>>
+  void (null as unknown as _t)
+}
+
+// -----------------------------------------------------------------------------
+// `omit` keeps the input shape (the type signature is intentionally loose;
+// we only assert the function is callable with the expected signature).
+// -----------------------------------------------------------------------------
+{
+  const result = omit({ a: 1, b: 'x', c: true }, ['a'])
+  type _t = Expect<Assignable<object, typeof result>>
+  void (null as unknown as _t)
+}
+
+// -----------------------------------------------------------------------------
+// `cascade` accepts any value and unknown args.
+// -----------------------------------------------------------------------------
+{
+  const result = cascade(1)
+  void result
+  const result2 = cascade((x: number) => x * 2, 21)
+  void result2
+}
+
+// -----------------------------------------------------------------------------
+// Re-export types are not `never` / `any`.
+// -----------------------------------------------------------------------------
+export type _itheme_not_never = Expect<
+  [ITheme] extends [never] ? false : true
+>

--- a/packages/util/tsconfig.json
+++ b/packages/util/tsconfig.json
@@ -1,6 +1,10 @@
 {
-  "include": ["src"],
-  "exclude": ["src/__type-tests__"],
+  "include": [
+    "src"
+  ],
+  "exclude": [
+    "src/__type-tests__"
+  ],
   "compilerOptions": {
     "strict": true,
     "noUnusedLocals": true,
@@ -12,6 +16,21 @@
     "esModuleInterop": true,
     "moduleResolution": "node",
     "jsx": "react",
-    "sourceMap": true
+    "sourceMap": true,
+    "baseUrl": ".",
+    "paths": {
+      "@xstyled/util": [
+        "../util/src"
+      ],
+      "@xstyled/prop-types": [
+        "../prop-types/src"
+      ],
+      "@xstyled/system": [
+        "../system/src"
+      ],
+      "@xstyled/core": [
+        "../core/src"
+      ]
+    }
   }
 }

--- a/packages/util/tsconfig.json
+++ b/packages/util/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "include": ["src"],
+  "exclude": ["src/__type-tests__"],
   "compilerOptions": {
     "strict": true,
     "noUnusedLocals": true,

--- a/packages/util/tsconfig.types.json
+++ b/packages/util/tsconfig.types.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src/__type-tests__"],
+  "exclude": [],
+  "compilerOptions": {
+    "noEmit": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "skipLibCheck": true
+  }
+}

--- a/scripts/bench-types.mjs
+++ b/scripts/bench-types.mjs
@@ -25,15 +25,33 @@ const __dirname = dirname(fileURLToPath(import.meta.url))
 const repoRoot = join(__dirname, '..')
 const tscBin = join(repoRoot, 'node_modules', '.bin', 'tsc')
 
-const arg = (name, fallback) => {
-  const i = process.argv.indexOf(name)
-  return i >= 0 ? process.argv[i + 1] : fallback
+const usage = (msg) => {
+  if (msg) console.error(`error: ${msg}`)
+  console.error(
+    'usage: node scripts/bench-types.mjs [--sizes <n,n,...>]\n' +
+      '       --sizes  comma-separated list of token counts (default: 50,200,500)',
+  )
+  process.exit(msg ? 2 : 0)
 }
 
-const sizes = (arg('--sizes', '50,200,500'))
+const arg = (name, fallback) => {
+  const i = process.argv.indexOf(name)
+  if (i < 0) return fallback
+  const next = process.argv[i + 1]
+  if (next === undefined || next.startsWith('--')) {
+    usage(`missing value for ${name}`)
+  }
+  return next
+}
+
+if (process.argv.includes('--help') || process.argv.includes('-h')) usage()
+
+const sizesArg = arg('--sizes', '50,200,500')
+const sizes = sizesArg
   .split(',')
-  .map((s) => parseInt(s, 10))
+  .map((s) => parseInt(s.trim(), 10))
   .filter(Number.isFinite)
+if (sizes.length === 0) usage(`--sizes received no valid integers: "${sizesArg}"`)
 
 const fixturesRoot = mkdtempSync(join(tmpdir(), 'xstyled-typebench-'))
 

--- a/scripts/bench-types.mjs
+++ b/scripts/bench-types.mjs
@@ -128,7 +128,10 @@ void _v3
 void _v4
 `
 
-const fixtureTsconfig = {
+// Resolve workspace deps from source so the bench works without a prior
+// `yarn build`. `baseUrl` is the fixture dir (created per-run); paths
+// reach back into the repo via relative segments computed at fixture time.
+const fixtureTsconfig = (fixtureDir) => ({
   compilerOptions: {
     strict: true,
     skipLibCheck: true,
@@ -140,11 +143,24 @@ const fixtureTsconfig = {
     noUnusedLocals: false,
     noUnusedParameters: false,
     jsx: 'react',
-    types: [],
+    // Resolve source files reference `process.env`; pull in @types/node
+    // from the repo (the fixture lives in /tmp, outside the repo's
+    // node_modules walk).
+    typeRoots: [importFrom(fixtureDir, 'node_modules/@types')],
+    types: ['node'],
     lib: ['esnext', 'dom'],
+    baseUrl: '.',
+    paths: {
+      '@xstyled/util': [importFrom(fixtureDir, 'packages/util/src')],
+      '@xstyled/prop-types': [
+        importFrom(fixtureDir, 'packages/prop-types/src'),
+      ],
+      '@xstyled/system': [importFrom(fixtureDir, 'packages/system/src')],
+      '@xstyled/core': [importFrom(fixtureDir, 'packages/core/src')],
+    },
   },
   include: ['fixture.ts'],
-}
+})
 
 const parseDiag = (stdout) => {
   const out = {}
@@ -176,7 +192,7 @@ try {
     writeFileSync(join(dir, 'fixture.ts'), buildFixture(n, dir))
     writeFileSync(
       join(dir, 'tsconfig.json'),
-      JSON.stringify(fixtureTsconfig, null, 2),
+      JSON.stringify(fixtureTsconfig(dir), null, 2),
     )
     const t0 = process.hrtime.bigint()
     const proc = spawnSync(

--- a/scripts/bench-types.mjs
+++ b/scripts/bench-types.mjs
@@ -18,12 +18,18 @@
 import { spawnSync } from 'node:child_process'
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
-import { dirname, join } from 'node:path'
+import { dirname, join, relative } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const repoRoot = join(__dirname, '..')
-const tscBin = join(repoRoot, 'node_modules', '.bin', 'tsc')
+// On Windows the yarn bin shim is `tsc.cmd`; spawnSync needs the exact name.
+const tscBin = join(
+  repoRoot,
+  'node_modules',
+  '.bin',
+  process.platform === 'win32' ? 'tsc.cmd' : 'tsc',
+)
 
 const usage = (msg) => {
   if (msg) console.error(`error: ${msg}`)
@@ -79,19 +85,27 @@ ${colors.join(',\n')}
 }`
 }
 
-const buildFixture = (n) => `
-import type { Color } from '${join(
-  repoRoot,
+// TS treats `C:/foo` as a bare specifier on Windows. Generate a
+// `./../...` relative path from the fixture directory so the bench is
+// cross-platform.
+const importFrom = (fixtureDir, target) => {
+  const rel = relative(fixtureDir, join(repoRoot, target)).replace(/\\/g, '/')
+  return rel.startsWith('.') ? rel : `./${rel}`
+}
+
+const buildFixture = (n, fixtureDir) => `
+import type { Color } from '${importFrom(
+  fixtureDir,
   'packages/system/src/styles/colors',
-).replace(/\\/g, '/')}'
-import type { Space } from '${join(
-  repoRoot,
+)}'
+import type { Space } from '${importFrom(
+  fixtureDir,
   'packages/system/src/styles/space',
-).replace(/\\/g, '/')}'
-import type { SystemProp } from '${join(
-  repoRoot,
+)}'
+import type { SystemProp } from '${importFrom(
+  fixtureDir,
   'packages/system/src/types',
-).replace(/\\/g, '/')}'
+)}'
 
 interface BenchTheme ${buildTheme(n)}
 
@@ -155,7 +169,7 @@ const results = []
 for (const n of sizes) {
   const dir = join(fixturesRoot, `n${n}`)
   mkdirSync(dir, { recursive: true })
-  writeFileSync(join(dir, 'fixture.ts'), buildFixture(n))
+  writeFileSync(join(dir, 'fixture.ts'), buildFixture(n, dir))
   writeFileSync(
     join(dir, 'tsconfig.json'),
     JSON.stringify(fixtureTsconfig, null, 2),

--- a/scripts/bench-types.mjs
+++ b/scripts/bench-types.mjs
@@ -1,0 +1,197 @@
+#!/usr/bin/env node
+/* eslint-disable no-console */
+/**
+ * Measure how expensive xstyled's types are for TypeScript to check.
+ *
+ * Generates synthetic theme files of varying sizes (color/space token counts
+ * mirroring real-world themes), runs `tsc --noEmit --extendedDiagnostics`
+ * against each, and reports Identifiers / Symbols / Types / Instantiations /
+ * Check time / Memory used as a small table.
+ *
+ * Use it as a regression watchdog: numbers should move locally as you change
+ * generic types, and a 2x jump in Instantiations is a smell.
+ *
+ *   node scripts/bench-types.mjs           # runs the default 50/200/500 mix
+ *   node scripts/bench-types.mjs --sizes 100,1000
+ */
+
+import { spawnSync } from 'node:child_process'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const repoRoot = join(__dirname, '..')
+const tscBin = join(repoRoot, 'node_modules', '.bin', 'tsc')
+
+const arg = (name, fallback) => {
+  const i = process.argv.indexOf(name)
+  return i >= 0 ? process.argv[i + 1] : fallback
+}
+
+const sizes = (arg('--sizes', '50,200,500'))
+  .split(',')
+  .map((s) => parseInt(s, 10))
+  .filter(Number.isFinite)
+
+const fixturesRoot = mkdtempSync(join(tmpdir(), 'xstyled-typebench-'))
+
+const buildTheme = (n) => {
+  const colors = []
+  for (let i = 0; i < n; i++) colors.push(`  'c${i}': '#000000'`)
+  return `{
+  colors: {
+${colors.join(',\n')}
+  },
+  space: {
+    sm: '4px',
+    md: '8px',
+    lg: '16px',
+  },
+  screens: {
+    sm: 640,
+    md: 768,
+    lg: 1024,
+  },
+  states: {
+    hover: '&:hover',
+    focus: '&:focus',
+  },
+}`
+}
+
+const buildFixture = (n) => `
+import type { Color } from '${join(
+  repoRoot,
+  'packages/system/src/styles/colors',
+).replace(/\\/g, '/')}'
+import type { Space } from '${join(
+  repoRoot,
+  'packages/system/src/styles/space',
+).replace(/\\/g, '/')}'
+import type { SystemProp } from '${join(
+  repoRoot,
+  'packages/system/src/types',
+).replace(/\\/g, '/')}'
+
+interface BenchTheme ${buildTheme(n)}
+
+type CProp = SystemProp<Color<BenchTheme>, BenchTheme>
+type SProp = SystemProp<Space<BenchTheme>, BenchTheme>
+
+declare const _c: CProp
+declare const _s: SProp
+
+const _v1: CProp = 'c0'
+const _v2: CProp = { sm: 'c0', md: 'c${Math.floor(n / 2)}' }
+const _v3: SProp = 'md'
+const _v4: SProp = { sm: 'sm', md: 'md', lg: 'lg' }
+
+void _c
+void _s
+void _v1
+void _v2
+void _v3
+void _v4
+`
+
+const fixtureTsconfig = {
+  compilerOptions: {
+    strict: true,
+    skipLibCheck: true,
+    target: 'esnext',
+    module: 'esnext',
+    moduleResolution: 'node',
+    esModuleInterop: true,
+    noEmit: true,
+    noUnusedLocals: false,
+    noUnusedParameters: false,
+    jsx: 'react',
+    types: [],
+    lib: ['esnext', 'dom'],
+  },
+  include: ['fixture.ts'],
+}
+
+const parseDiag = (stdout) => {
+  const out = {}
+  const fields = [
+    ['files', /Files:\s+(\d+)/],
+    ['identifiers', /Identifiers:\s+(\d+)/],
+    ['symbols', /Symbols:\s+(\d+)/],
+    ['types', /^Types:\s+(\d+)/m],
+    ['instantiations', /Instantiations:\s+(\d+)/],
+    ['memoryKB', /Memory used:\s+(\d+)K/],
+    ['checkTimeSec', /Check time:\s+([\d.]+)s/],
+    ['totalTimeSec', /Total time:\s+([\d.]+)s/],
+  ]
+  for (const [name, re] of fields) {
+    const m = stdout.match(re)
+    out[name] = m ? Number(m[1]) : null
+  }
+  return out
+}
+
+const results = []
+for (const n of sizes) {
+  const dir = join(fixturesRoot, `n${n}`)
+  mkdirSync(dir, { recursive: true })
+  writeFileSync(join(dir, 'fixture.ts'), buildFixture(n))
+  writeFileSync(
+    join(dir, 'tsconfig.json'),
+    JSON.stringify(fixtureTsconfig, null, 2),
+  )
+  const t0 = process.hrtime.bigint()
+  const proc = spawnSync(
+    tscBin,
+    ['--noEmit', '--extendedDiagnostics', '-p', 'tsconfig.json'],
+    { cwd: dir, encoding: 'utf8' },
+  )
+  const wallMs = Number((process.hrtime.bigint() - t0) / 1_000_000n)
+  if (proc.status !== 0 && proc.stdout && !/Instantiations:/.test(proc.stdout)) {
+    console.error(`tsc failed for n=${n}`)
+    console.error(proc.stdout)
+    console.error(proc.stderr)
+    process.exit(1)
+  }
+  const diag = parseDiag(proc.stdout || '')
+  results.push({ n, wallMs, ...diag })
+}
+
+const fmt = (v) => (v == null ? '—' : typeof v === 'number' ? v.toLocaleString() : v)
+const header = [
+  'tokens',
+  'wall(ms)',
+  'check(s)',
+  'total(s)',
+  'instantiations',
+  'types',
+  'symbols',
+  'identifiers',
+  'memory(KB)',
+]
+
+const rows = results.map((r) => [
+  r.n,
+  r.wallMs,
+  r.checkTimeSec,
+  r.totalTimeSec,
+  r.instantiations,
+  r.types,
+  r.symbols,
+  r.identifiers,
+  r.memoryKB,
+])
+
+const widths = header.map((h, i) =>
+  Math.max(h.length, ...rows.map((row) => String(fmt(row[i])).length)),
+)
+const pad = (s, w) => String(s).padStart(w)
+console.log(header.map((h, i) => pad(h, widths[i])).join('  '))
+console.log(widths.map((w) => '-'.repeat(w)).join('  '))
+for (const row of rows) {
+  console.log(row.map((v, i) => pad(fmt(v), widths[i])).join('  '))
+}
+
+rmSync(fixturesRoot, { recursive: true, force: true })

--- a/scripts/bench-types.mjs
+++ b/scripts/bench-types.mjs
@@ -58,6 +58,13 @@ const sizes = sizesArg
   .map((s) => parseInt(s.trim(), 10))
   .filter(Number.isFinite)
 if (sizes.length === 0) usage(`--sizes received no valid integers: "${sizesArg}"`)
+const tooSmall = sizes.filter((n) => n < 1)
+if (tooSmall.length > 0) {
+  // The fixture references `'c0'` and `'c${Math.floor(n/2)}'`; sizes < 1
+  // would generate themes with no `c0`, which produces noisy/misleading
+  // type errors rather than a meaningful bench.
+  usage(`--sizes must all be >= 1; got: ${tooSmall.join(', ')}`)
+}
 
 const fixturesRoot = mkdtempSync(join(tmpdir(), 'xstyled-typebench-'))
 

--- a/scripts/bench-types.mjs
+++ b/scripts/bench-types.mjs
@@ -167,17 +167,23 @@ for (const n of sizes) {
     { cwd: dir, encoding: 'utf8' },
   )
   const wallMs = Number((process.hrtime.bigint() - t0) / 1_000_000n)
-  if (proc.status !== 0 && proc.stdout && !/Instantiations:/.test(proc.stdout)) {
-    console.error(`tsc failed for n=${n}`)
-    console.error(proc.stdout)
-    console.error(proc.stderr)
-    process.exit(1)
+  if (proc.status !== 0) {
+    if (!proc.stdout || !/Instantiations:/.test(proc.stdout)) {
+      console.error(`tsc failed for n=${n}`)
+      console.error(proc.stdout)
+      console.error(proc.stderr)
+      process.exit(1)
+    }
+    // tsc reported type errors but still produced diagnostics; the perf
+    // numbers are valid, but the fixture isn't well-formed. Surface it so
+    // a regression doesn't silently turn into a "look how fast" win.
+    console.error(`warn: tsc exited ${proc.status} for n=${n}; bench numbers retained but the fixture has type errors`)
   }
   const diag = parseDiag(proc.stdout || '')
   results.push({ n, wallMs, ...diag })
 }
 
-const fmt = (v) => (v == null ? '—' : typeof v === 'number' ? v.toLocaleString() : v)
+const fmt = (v) => (v == null ? '-' : typeof v === 'number' ? v.toLocaleString() : v)
 const header = [
   'tokens',
   'wall(ms)',

--- a/scripts/bench-types.mjs
+++ b/scripts/bench-types.mjs
@@ -165,71 +165,84 @@ const parseDiag = (stdout) => {
   return out
 }
 
-const results = []
-for (const n of sizes) {
-  const dir = join(fixturesRoot, `n${n}`)
-  mkdirSync(dir, { recursive: true })
-  writeFileSync(join(dir, 'fixture.ts'), buildFixture(n, dir))
-  writeFileSync(
-    join(dir, 'tsconfig.json'),
-    JSON.stringify(fixtureTsconfig, null, 2),
-  )
-  const t0 = process.hrtime.bigint()
-  const proc = spawnSync(
-    tscBin,
-    ['--noEmit', '--extendedDiagnostics', '-p', 'tsconfig.json'],
-    { cwd: dir, encoding: 'utf8' },
-  )
-  const wallMs = Number((process.hrtime.bigint() - t0) / 1_000_000n)
-  if (proc.status !== 0) {
-    if (!proc.stdout || !/Instantiations:/.test(proc.stdout)) {
-      console.error(`tsc failed for n=${n}`)
-      console.error(proc.stdout)
-      console.error(proc.stderr)
-      process.exit(1)
+// Wrap the body in try/finally so the temp fixturesRoot is always cleaned
+// up — including the `process.exit(1)` path on a hard tsc failure.
+let exitCode = 0
+try {
+  const results = []
+  for (const n of sizes) {
+    const dir = join(fixturesRoot, `n${n}`)
+    mkdirSync(dir, { recursive: true })
+    writeFileSync(join(dir, 'fixture.ts'), buildFixture(n, dir))
+    writeFileSync(
+      join(dir, 'tsconfig.json'),
+      JSON.stringify(fixtureTsconfig, null, 2),
+    )
+    const t0 = process.hrtime.bigint()
+    const proc = spawnSync(
+      tscBin,
+      ['--noEmit', '--extendedDiagnostics', '-p', 'tsconfig.json'],
+      { cwd: dir, encoding: 'utf8' },
+    )
+    const wallMs = Number((process.hrtime.bigint() - t0) / 1_000_000n)
+    if (proc.status !== 0) {
+      if (!proc.stdout || !/Instantiations:/.test(proc.stdout)) {
+        console.error(`tsc failed for n=${n}`)
+        console.error(proc.stdout)
+        console.error(proc.stderr)
+        exitCode = 1
+        break
+      }
+      // tsc reported type errors but still produced diagnostics; the perf
+      // numbers are valid, but the fixture isn't well-formed. Surface it so
+      // a regression doesn't silently turn into a "look how fast" win.
+      console.error(
+        `warn: tsc exited ${proc.status} for n=${n}; bench numbers retained but the fixture has type errors`,
+      )
     }
-    // tsc reported type errors but still produced diagnostics; the perf
-    // numbers are valid, but the fixture isn't well-formed. Surface it so
-    // a regression doesn't silently turn into a "look how fast" win.
-    console.error(`warn: tsc exited ${proc.status} for n=${n}; bench numbers retained but the fixture has type errors`)
+    const diag = parseDiag(proc.stdout || '')
+    results.push({ n, wallMs, ...diag })
   }
-  const diag = parseDiag(proc.stdout || '')
-  results.push({ n, wallMs, ...diag })
+
+  if (exitCode === 0) {
+    const fmt = (v) =>
+      v == null ? '-' : typeof v === 'number' ? v.toLocaleString() : v
+    const header = [
+      'tokens',
+      'wall(ms)',
+      'check(s)',
+      'total(s)',
+      'instantiations',
+      'types',
+      'symbols',
+      'identifiers',
+      'memory(KB)',
+    ]
+
+    const rows = results.map((r) => [
+      r.n,
+      r.wallMs,
+      r.checkTimeSec,
+      r.totalTimeSec,
+      r.instantiations,
+      r.types,
+      r.symbols,
+      r.identifiers,
+      r.memoryKB,
+    ])
+
+    const widths = header.map((h, i) =>
+      Math.max(h.length, ...rows.map((row) => String(fmt(row[i])).length)),
+    )
+    const pad = (s, w) => String(s).padStart(w)
+    console.log(header.map((h, i) => pad(h, widths[i])).join('  '))
+    console.log(widths.map((w) => '-'.repeat(w)).join('  '))
+    for (const row of rows) {
+      console.log(row.map((v, i) => pad(fmt(v), widths[i])).join('  '))
+    }
+  }
+} finally {
+  rmSync(fixturesRoot, { recursive: true, force: true })
 }
 
-const fmt = (v) => (v == null ? '-' : typeof v === 'number' ? v.toLocaleString() : v)
-const header = [
-  'tokens',
-  'wall(ms)',
-  'check(s)',
-  'total(s)',
-  'instantiations',
-  'types',
-  'symbols',
-  'identifiers',
-  'memory(KB)',
-]
-
-const rows = results.map((r) => [
-  r.n,
-  r.wallMs,
-  r.checkTimeSec,
-  r.totalTimeSec,
-  r.instantiations,
-  r.types,
-  r.symbols,
-  r.identifiers,
-  r.memoryKB,
-])
-
-const widths = header.map((h, i) =>
-  Math.max(h.length, ...rows.map((row) => String(fmt(row[i])).length)),
-)
-const pad = (s, w) => String(s).padStart(w)
-console.log(header.map((h, i) => pad(h, widths[i])).join('  '))
-console.log(widths.map((w) => '-'.repeat(w)).join('  '))
-for (const row of rows) {
-  console.log(row.map((v, i) => pad(fmt(v), widths[i])).join('  '))
-}
-
-rmSync(fixturesRoot, { recursive: true, force: true })
+if (exitCode !== 0) process.exit(exitCode)

--- a/scripts/check-types.mjs
+++ b/scripts/check-types.mjs
@@ -7,7 +7,8 @@
  *
  *   yarn check:types
  *
- * Exits non-zero on the first failure.
+ * Runs every project even if one fails so all failures are visible in a
+ * single CI run, then exits non-zero at the end if anything failed.
  */
 import { spawnSync } from 'node:child_process'
 import { existsSync } from 'node:fs'

--- a/scripts/check-types.mjs
+++ b/scripts/check-types.mjs
@@ -63,7 +63,10 @@ let failed = 0
 for (const rel of projects) {
   const abs = join(repoRoot, rel)
   if (!existsSync(abs)) {
-    console.log(`\x1b[33mskip\x1b[0m  ${rel} (not found)`)
+    // `projects` is hard-coded, so a missing tsconfig means the matrix
+    // is no longer complete. Fail loudly rather than quietly skipping.
+    console.log(`\x1b[31mFAIL\x1b[0m  ${rel} (not found — projects list out of sync)`)
+    failed += 1
     continue
   }
   if (isAug(rel) && !existsSync(systemDts)) {

--- a/scripts/check-types.mjs
+++ b/scripts/check-types.mjs
@@ -19,7 +19,13 @@ import { fileURLToPath } from 'node:url'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const repoRoot = join(__dirname, '..')
-const tscBin = join(repoRoot, 'node_modules', '.bin', 'tsc')
+// On Windows the yarn bin shim is `tsc.cmd`; spawnSync needs the exact name.
+const tscBin = join(
+  repoRoot,
+  'node_modules',
+  '.bin',
+  process.platform === 'win32' ? 'tsc.cmd' : 'tsc',
+)
 
 // Order matters: util has no deps, system depends on util, styled-components /
 // emotion depend on system. Each package's main tsconfig.json is also

--- a/scripts/check-types.mjs
+++ b/scripts/check-types.mjs
@@ -48,25 +48,29 @@ const projects = [
   'packages/babel-preset-emotion-css-prop/tsconfig.json',
 ]
 
-// The augmentation contract test resolves `@xstyled/system` via the
-// workspace symlink → `package.json#types` → `dist/index.d.ts`. Without a
-// prior `yarn build` the import dangles and tsc reports a misleading
-// "cannot find module" instead of the missing-prerequisite. Surface it.
+// The augmentation contract test (packages/system/tsconfig.aug.json) is the
+// only project that resolves `@xstyled/system` via the workspace symlink →
+// `package.json#types` → `dist/index.d.ts`. Without a prior `yarn build` the
+// import dangles and tsc reports a misleading "cannot find module" instead
+// of the missing-prerequisite — so scope the dist check to just that project
+// and skip with a clear message; every other project is independent of the
+// built dist and still runs.
 const systemDts = join(repoRoot, 'packages/system/dist/index.d.ts')
-if (!existsSync(systemDts)) {
-  console.error(
-    '\x1b[31merror\x1b[0m  packages/system/dist/index.d.ts is missing.\n' +
-      '       run `yarn build` first; the augmentation test resolves\n' +
-      '       `@xstyled/system` through the built dist.',
-  )
-  process.exit(1)
-}
+const needsBuiltSystemDist = (rel) =>
+  rel === 'packages/system/tsconfig.aug.json'
 
 let failed = 0
 for (const rel of projects) {
   const abs = join(repoRoot, rel)
   if (!existsSync(abs)) {
-    console.log(`[33mskip[0m  ${rel} (not found)`)
+    console.log(`\x1b[33mskip\x1b[0m  ${rel} (not found)`)
+    continue
+  }
+  if (needsBuiltSystemDist(rel) && !existsSync(systemDts)) {
+    console.log(
+      `\x1b[33mskip\x1b[0m  ${rel} (run \`yarn build\` first; resolves @xstyled/system through dist/)`,
+    )
+    failed += 1
     continue
   }
   process.stdout.write(`check  ${rel} ... `)
@@ -79,9 +83,9 @@ for (const rel of projects) {
   })
   const ms = Number((process.hrtime.bigint() - t0) / 1_000_000n)
   if (proc.status === 0) {
-    console.log(`[32mok[0m (${ms}ms)`)
+    console.log(`\x1b[32mok\x1b[0m (${ms}ms)`)
   } else {
-    console.log(`[31mFAIL[0m (${ms}ms)`)
+    console.log(`\x1b[31mFAIL\x1b[0m (${ms}ms)`)
     if (proc.stdout) console.log(proc.stdout)
     if (proc.stderr) console.error(proc.stderr)
     failed += 1

--- a/scripts/check-types.mjs
+++ b/scripts/check-types.mjs
@@ -1,9 +1,11 @@
 #!/usr/bin/env node
 /* eslint-disable no-console */
 /**
- * Runs every `tsconfig.types*.json` we have, one after another, with the
- * same `tsc` binary. Each project is reported with timing so a slow project
- * is easy to spot.
+ * Type-checks every package: the main `tsconfig.json` (for src and test
+ * files that the rollup-dts build doesn't reach) and the dedicated
+ * `tsconfig.types*.json` files (for the __type-tests__ folders and the
+ * system augmentation contract). Each project is reported with timing so
+ * a slow one is easy to spot.
  *
  *   yarn check:types
  *
@@ -20,14 +22,39 @@ const repoRoot = join(__dirname, '..')
 const tscBin = join(repoRoot, 'node_modules', '.bin', 'tsc')
 
 // Order matters: util has no deps, system depends on util, styled-components /
-// emotion depend on system.
+// emotion depend on system. Each package's main tsconfig.json is also
+// type-checked here (with --noEmit) so test files and other src that isn't
+// reachable from `src/index.ts` still gets covered — rollup-plugin-dts only
+// follows imports from the entry point and skips test files, so latent
+// errors there would otherwise hide indefinitely.
 const projects = [
+  'packages/util/tsconfig.json',
   'packages/util/tsconfig.types.json',
+  'packages/prop-types/tsconfig.json',
+  'packages/system/tsconfig.json',
   'packages/system/tsconfig.types.json',
   'packages/system/tsconfig.aug.json',
+  'packages/core/tsconfig.json',
+  'packages/styled-components/tsconfig.json',
   'packages/styled-components/tsconfig.types.json',
+  'packages/emotion/tsconfig.json',
   'packages/emotion/tsconfig.types.json',
+  'packages/babel-preset-emotion-css-prop/tsconfig.json',
 ]
+
+// The augmentation contract test resolves `@xstyled/system` via the
+// workspace symlink → `package.json#types` → `dist/index.d.ts`. Without a
+// prior `yarn build` the import dangles and tsc reports a misleading
+// "cannot find module" instead of the missing-prerequisite. Surface it.
+const systemDts = join(repoRoot, 'packages/system/dist/index.d.ts')
+if (!existsSync(systemDts)) {
+  console.error(
+    '\x1b[31merror\x1b[0m  packages/system/dist/index.d.ts is missing.\n' +
+      '       run `yarn build` first; the augmentation test resolves\n' +
+      '       `@xstyled/system` through the built dist.',
+  )
+  process.exit(1)
+}
 
 let failed = 0
 for (const rel of projects) {
@@ -38,7 +65,9 @@ for (const rel of projects) {
   }
   process.stdout.write(`check  ${rel} ... `)
   const t0 = process.hrtime.bigint()
-  const proc = spawnSync(tscBin, ['-p', abs], {
+  // Main tsconfigs don't have `noEmit` set by default (they're used for the
+  // build's dts step). Pass it explicitly so we type-check without writing.
+  const proc = spawnSync(tscBin, ['-p', abs, '--noEmit', '--skipLibCheck'], {
     cwd: repoRoot,
     encoding: 'utf8',
   })
@@ -54,7 +83,7 @@ for (const rel of projects) {
 }
 
 if (failed > 0) {
-  console.error(`\n${failed} type-test project(s) failed.`)
+  console.error(`\n${failed} project(s) failed.`)
   process.exit(1)
 }
-console.log('\nAll type-test projects passed.')
+console.log('\nAll projects passed.')

--- a/scripts/check-types.mjs
+++ b/scripts/check-types.mjs
@@ -48,16 +48,16 @@ const projects = [
   'packages/babel-preset-emotion-css-prop/tsconfig.json',
 ]
 
-// The augmentation contract test (packages/system/tsconfig.aug.json) is the
-// only project that resolves `@xstyled/system` via the workspace symlink →
-// `package.json#types` → `dist/index.d.ts`. Without a prior `yarn build` the
-// import dangles and tsc reports a misleading "cannot find module" instead
-// of the missing-prerequisite — so scope the dist check to just that project
-// and skip with a clear message; every other project is independent of the
-// built dist and still runs.
+// Workspace deps resolve from source via tsconfig `paths`, so no prior
+// `yarn build` is required for the per-package type-checks. The one
+// exception is `packages/system/tsconfig.aug.json`: that project exercises
+// the *consumer* contract (`declare module '@xstyled/system'` through the
+// published `dist/index.d.ts`) and therefore deliberately resolves the
+// package via node_modules, not source. Skip it cleanly (no failure)
+// when dist isn't built so a fresh-checkout run produces no scary noise;
+// CI always builds first.
 const systemDts = join(repoRoot, 'packages/system/dist/index.d.ts')
-const needsBuiltSystemDist = (rel) =>
-  rel === 'packages/system/tsconfig.aug.json'
+const isAug = (rel) => rel === 'packages/system/tsconfig.aug.json'
 
 let failed = 0
 for (const rel of projects) {
@@ -66,11 +66,10 @@ for (const rel of projects) {
     console.log(`\x1b[33mskip\x1b[0m  ${rel} (not found)`)
     continue
   }
-  if (needsBuiltSystemDist(rel) && !existsSync(systemDts)) {
+  if (isAug(rel) && !existsSync(systemDts)) {
     console.log(
-      `\x1b[33mskip\x1b[0m  ${rel} (run \`yarn build\` first; resolves @xstyled/system through dist/)`,
+      `\x1b[33mskip\x1b[0m  ${rel} (run \`yarn build\` first to exercise the consumer contract)`,
     )
-    failed += 1
     continue
   }
   process.stdout.write(`check  ${rel} ... `)

--- a/scripts/check-types.mjs
+++ b/scripts/check-types.mjs
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+/* eslint-disable no-console */
+/**
+ * Runs every `tsconfig.types*.json` we have, one after another, with the
+ * same `tsc` binary. Each project is reported with timing so a slow project
+ * is easy to spot.
+ *
+ *   yarn check:types
+ *
+ * Exits non-zero on the first failure.
+ */
+import { spawnSync } from 'node:child_process'
+import { existsSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const repoRoot = join(__dirname, '..')
+const tscBin = join(repoRoot, 'node_modules', '.bin', 'tsc')
+
+// Order matters: util has no deps, system depends on util, styled-components /
+// emotion depend on system.
+const projects = [
+  'packages/util/tsconfig.types.json',
+  'packages/system/tsconfig.types.json',
+  'packages/system/tsconfig.aug.json',
+  'packages/styled-components/tsconfig.types.json',
+  'packages/emotion/tsconfig.types.json',
+]
+
+let failed = 0
+for (const rel of projects) {
+  const abs = join(repoRoot, rel)
+  if (!existsSync(abs)) {
+    console.log(`[33mskip[0m  ${rel} (not found)`)
+    continue
+  }
+  process.stdout.write(`check  ${rel} ... `)
+  const t0 = process.hrtime.bigint()
+  const proc = spawnSync(tscBin, ['-p', abs], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+  })
+  const ms = Number((process.hrtime.bigint() - t0) / 1_000_000n)
+  if (proc.status === 0) {
+    console.log(`[32mok[0m (${ms}ms)`)
+  } else {
+    console.log(`[31mFAIL[0m (${ms}ms)`)
+    if (proc.stdout) console.log(proc.stdout)
+    if (proc.stderr) console.error(proc.stderr)
+    failed += 1
+  }
+}
+
+if (failed > 0) {
+  console.error(`\n${failed} type-test project(s) failed.`)
+  process.exit(1)
+}
+console.log('\nAll type-test projects passed.')


### PR DESCRIPTION
## Summary

Two things in one branch, both anchored on a type-level bug in `SynthesizedPath`:

### 1. `SynthesizedPath` fix (#413, partial #429)

- **Numeric keys are now preserved.** `{ blue: { 50: '#…' } }` resolves to `'blue.50'` instead of silently dropping out of the union. The old `P extends string` filter excluded numeric keys; the new `keyof T & (string | number)` with a `` `${P}` `` template captures them as string-form path segments.
- **Recursion is depth-bounded.** A `_SynthesizedPathDepth = [never, 0, 1, 2, 3, 4, 5, 6]` tail tuple caps recursion at depth 6 with a `string` widening at the bottom, so pathologically deep themes don't produce an "unrepresentable union" error. Doesn't fix the breadth case (flat object with 100+ tokens) — see `Refs`.

### 2. Type-test suite across the public API

Every public package now has a `src/__type-tests__/` folder with a dedicated `tsconfig.types.json`, excluded from the main tsconfig and from jest. A small chained runner (`scripts/check-types.mjs`, `yarn check:types`) walks all 12 projects (each package's `tsconfig.json` plus the dedicated types tsconfigs) and reports per-project timing. CI runs it between `lint` and `test`.

What's covered:

- **`@xstyled/util`**: `is`/`num`/`string`/`obj`/`func`/`negative` narrowing predicates, `assign`/`merge`/`omit`/`cascade` return shapes.
- **`@xstyled/system`**: `SynthesizedPath` (flat / nested / numeric / deep-10), `Color` / `ThemeColor`, `Space` / `ThemeSpace` / `Pixel`, `SystemProp` / `ThemeProp` / `ThemeVariants`, `th` and getters, `compose()` plus `StyleGeneratorPropsConcat`, plus a `Theme` augmentation contract test in its own isolated `tsconfig.aug.json`.
- **`@xstyled/styled-components`** and **`@xstyled/emotion`**: `x.div` / `x.a` / `x.button` JSX, `styled.div` plus `.attrs` / `.withConfig`, `css`, `createGlobalStyle`, `keyframes`, every `use*` hook including the breakpoint hooks rejecting non-`(string|number)` keys.

Every file pairs `Expect<Equal<...>>` / `Expect<Assignable<...>>` positives with `// @ts-expect-error` value-level negatives, so a regression that **stops** rejecting bad input fails CI just as loudly as one that breaks good input.

### 3. Type-perf bench (`yarn bench:types`)

`scripts/bench-types.mjs` synthesises themes of N tokens and runs `tsc --extendedDiagnostics`, reporting `Instantiations / Types / Check time / Memory`. Local before/after on the `SynthesizedPath` change at 50/200/500 colors:

| tokens | instantiations before | after |
| ---: | ---: | ---: |
| 50 | 8,487 | 8,675 |
| 200 | 9,837 | 9,875 |
| 500 | 12,537 | 12,275 |

Essentially flat. The depth tuple costs a handful of instantiations at small sizes and breaks even at larger ones.

## Heavy perf fixture

A `perf.test-d.ts` fixture with 55 colors plus nested `brand` scale, 19 space tokens, 5 screens, and 5 states keeps CI honest if a future change explodes Instantiations.

## Fixes

Fixes #413 — numeric keys in nested color objects now produce `'blue.50' | 'blue.100'` instead of silently dropping.

## Refs

- #429: partially mitigated. The depth guard caps recursion so pathologically nested themes can't blow up the union, but the breadth case (one flat object with 100+ tokens) is a separate problem that needs `Color` / `SystemProp` restructured for lazy evaluation. Saving for a follow-up.
- #428: the `(string & {}) | (number & {})` IntelliSense trick is regression-locked by `space.test-d.ts` and the existing `Pixel` continues to satisfy `IsAny extends true ? false : true`.
- #344, #417, #418: the `declare module '@xstyled/system' { interface Theme { ... } }` contract is pinned down in `packages/system/type-tests-aug/augmentation.test-d.ts`.
- #378: `useUp(key: string | number)` is locked in at the type level (booleans and objects rejected by `@ts-expect-error`). The runtime bug where `useUp(1024)` always returns `false` is separate.

## Slice context

Part of a 4-way split of the original triage branch. Sibling PRs:

- #439 — `chore: untrack .yarn/cache`
- `claude/modernize-node-ci-dependabot` (open) — Node 22, actions v4, dependabot grouping
- `claude/perf-cleanups-emotion-agents` (not yet opened) — `compose()` flatten + emotion fix + AGENTS.md

The check-types runner here also type-checks `packages/emotion/src/createCssFunction.ts`, which still has the `@ts-expect-error` workaround. The proper type fix lands in the perf/emotion PR. Two small test-file fixes (`Object.keys(res ?? {})` in `styles/index.test.ts`, dropping unused `(p)` param in `emotion/src/css.test.tsx`) are included here so the expanded runner passes standalone.

## Test plan

- [x] `yarn build`: 7 packages green
- [x] `yarn lint`: 0 errors (49 pre-existing warnings)
- [x] `yarn test`: 441 passed, 168 skipped
- [x] `yarn check:types`: all 12 projects pass
- [x] `yarn bench:types`: perf table at 50/200/500 colors produced

---
_Generated by [Claude Code](https://claude.ai/code/session_01ALWS9GHUD9RoapTXmtdAVx)_